### PR TITLE
feat: dashboard UI — responsive layout with dark theme

### DIFF
--- a/src/components/connection-status.js
+++ b/src/components/connection-status.js
@@ -1,0 +1,19 @@
+/**
+ * Connection status indicator component.
+ * Shows a colored dot + label in the top bar reflecting API connectivity.
+ */
+import { onConnectionChange, isConnected } from '../lib/api.js';
+
+export function initConnectionStatus() {
+  const dot = document.getElementById('conn-dot');
+  const text = document.getElementById('conn-text');
+
+  function render(ok) {
+    dot.className = ok ? 'dot green' : 'dot red';
+    text.textContent = ok ? 'Connected' : 'Disconnected';
+  }
+
+  // Set initial state
+  render(isConnected());
+  onConnectionChange(render);
+}

--- a/src/components/heartbeat.js
+++ b/src/components/heartbeat.js
@@ -1,0 +1,43 @@
+/**
+ * Heartbeat card component.
+ * Renders Ralph-watch heartbeat data: status dot, metadata fields, round info.
+ */
+import { fetchHeartbeat } from '../lib/api.js';
+import { timeAgo } from '../lib/util.js';
+
+export async function refreshHeartbeat() {
+  const hb = await fetchHeartbeat();
+  if (!hb) return;
+  renderHeartbeat(hb);
+}
+
+function renderHeartbeat(hb) {
+  const dot = document.getElementById('ralph-dot');
+  const statusText = document.getElementById('status-text');
+  const dataEl = document.getElementById('heartbeat-data');
+  const roundInfo = document.getElementById('round-info');
+
+  const statusMap = { idle: 'green', running: 'yellow', error: 'red', offline: 'gray' };
+  const statusClass = statusMap[hb.status] || 'gray';
+  dot.className = `dot ${statusClass}`;
+  statusText.textContent = hb.status
+    ? hb.status.charAt(0).toUpperCase() + hb.status.slice(1)
+    : 'Unknown';
+
+  const repos = hb.repos ? hb.repos.join(', ') : 'N/A';
+  const ago = timeAgo(hb.timestamp);
+
+  dataEl.innerHTML = `
+    <dt>Updated</dt><dd>${ago}</dd>
+    <dt>Round</dt><dd>${hb.round ?? '—'}</dd>
+    <dt>PID</dt><dd>${hb.pid ?? '—'}</dd>
+    <dt>Interval</dt><dd>${hb.interval ? hb.interval + ' min' : '—'}</dd>
+    <dt>Status</dt><dd>${hb.lastStatus || '—'}</dd>
+    <dt>Duration</dt><dd>${hb.lastDuration ? hb.lastDuration + 's' : '—'}</dd>
+    <dt>Failures</dt><dd>${hb.consecutiveFailures ?? 0}</dd>
+    <dt>Repos</dt><dd>${repos}</dd>
+  `;
+
+  roundInfo.textContent =
+    `Round ${hb.round ?? '?'} · Last run: ${hb.lastStatus || 'N/A'} (${hb.lastDuration ?? '?'}s)`;
+}

--- a/src/components/log-viewer.js
+++ b/src/components/log-viewer.js
@@ -1,0 +1,59 @@
+/**
+ * Log viewer component.
+ * Renders the activity log with filtering support.
+ */
+import { fetchLogs } from '../lib/api.js';
+
+const MAX_VISIBLE = 50;
+let currentFilter = 'all';
+
+export async function refreshLogs() {
+  const entries = await fetchLogs();
+  if (!entries) return;
+  renderLogs(entries);
+}
+
+export function initLogViewer() {
+  const toolbar = document.getElementById('log-toolbar');
+  if (!toolbar) return;
+
+  toolbar.addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-filter]');
+    if (!btn) return;
+    currentFilter = btn.dataset.filter;
+    toolbar.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    // Trigger a re-render with cached data
+    refreshLogs();
+  });
+}
+
+function renderLogs(entries) {
+  const el = document.getElementById('log-entries');
+  if (!entries || entries.length === 0) {
+    el.innerHTML = '<p class="empty-state">No log entries yet today.</p>';
+    return;
+  }
+
+  let filtered = entries;
+  if (currentFilter === 'success') {
+    filtered = entries.filter(e => e.exitCode === 0);
+  } else if (currentFilter === 'error') {
+    filtered = entries.filter(e => e.exitCode !== 0);
+  }
+
+  if (filtered.length === 0) {
+    el.innerHTML = `<p class="empty-state">No ${currentFilter} entries.</p>`;
+    return;
+  }
+
+  el.innerHTML = filtered.slice(-MAX_VISIBLE).reverse().map(e => {
+    const time = e.timestamp ? new Date(e.timestamp).toLocaleTimeString() : '?';
+    const icon = e.exitCode === 0 ? '✅' : '❌';
+    const cls = e.exitCode === 0 ? '' : ' log-error';
+    const metrics = e.metrics
+      ? ` <span class="log-metrics">issues=${e.metrics.issuesClosed || 0} prs=${e.metrics.prsMerged || 0}</span>`
+      : '';
+    return `<div class="log-entry${cls}">${icon} <span class="log-time">${time}</span> Round ${e.round || '?'} <span class="log-duration">(${e.duration || '?'}s)</span>${metrics}</div>`;
+  }).join('');
+}

--- a/src/components/repos.js
+++ b/src/components/repos.js
@@ -1,0 +1,46 @@
+/**
+ * Repos grid component.
+ * Renders studio repository cards with focus, issues, and last commit info.
+ */
+import { fetchRepos } from '../lib/api.js';
+import { escapeHtml } from '../lib/util.js';
+
+export async function refreshRepos() {
+  const repos = await fetchRepos();
+  if (!repos) return;
+  renderRepos(repos);
+}
+
+function renderRepos(repos) {
+  const grid = document.getElementById('repos-grid');
+  if (!repos || repos.length === 0) {
+    grid.innerHTML = '<div class="repo-card empty-state">No repo data available</div>';
+    return;
+  }
+
+  grid.innerHTML = repos.map(r => {
+    const focus = r.focus || 'No focus set';
+    const issues = r.openIssues !== null ? r.openIssues : '—';
+    const commit = r.lastCommit ? r.lastCommit.message : '—';
+    const sha = r.lastCommit ? r.lastCommit.sha : '';
+    const squadBadge = r.hasSquad ? '<span class="badge squad">squad</span>' : '';
+
+    return `
+      <div class="repo-card">
+        <div class="repo-header">
+          <span class="repo-emoji">${r.emoji}</span>
+          <span class="repo-name">${escapeHtml(r.label)}</span>
+          ${squadBadge}
+        </div>
+        <div class="repo-focus">${escapeHtml(focus)}</div>
+        <div class="repo-meta">
+          <span class="label">Issues</span> ${issues} open<br>
+          <span class="label">Commit</span> <code>${escapeHtml(sha)}</code> ${escapeHtml(commit)}
+        </div>
+        <a class="repo-link" href="https://github.com/${r.github}" target="_blank" rel="noopener">
+          github.com/${r.github} ↗
+        </a>
+      </div>
+    `;
+  }).join('');
+}

--- a/src/components/settings.js
+++ b/src/components/settings.js
@@ -1,0 +1,67 @@
+/**
+ * Settings panel component.
+ * Allows configuring auto-refresh intervals and pause/resume polling.
+ */
+
+const PRESETS = [
+  { label: '5s', value: 5000 },
+  { label: '10s', value: 10000 },
+  { label: '30s', value: 30000 },
+  { label: '1m', value: 60000 },
+];
+
+/** @param {import('../lib/scheduler.js').Scheduler} scheduler */
+export function initSettings(scheduler) {
+  const btn = document.getElementById('settings-toggle');
+  const panel = document.getElementById('settings-panel');
+  const refreshSelect = document.getElementById('refresh-interval');
+  const pauseBtn = document.getElementById('pause-btn');
+
+  if (!btn || !panel) return;
+
+  // Populate refresh presets
+  if (refreshSelect) {
+    refreshSelect.innerHTML = PRESETS.map(p =>
+      `<option value="${p.value}" ${p.value === scheduler.getInterval('heartbeat') ? 'selected' : ''}>${p.label}</option>`
+    ).join('');
+
+    refreshSelect.addEventListener('change', () => {
+      const val = parseInt(refreshSelect.value, 10);
+      scheduler.setInterval('heartbeat', val);
+      scheduler.setInterval('logs', val * 2);
+      scheduler.setInterval('repos', val * 6);
+      scheduler.setInterval('timeline', val * 2);
+    });
+  }
+
+  // Toggle panel
+  btn.addEventListener('click', () => {
+    panel.classList.toggle('open');
+    btn.setAttribute('aria-expanded', panel.classList.contains('open'));
+  });
+
+  // Close on outside click
+  document.addEventListener('click', (e) => {
+    if (!panel.contains(e.target) && !btn.contains(e.target)) {
+      panel.classList.remove('open');
+      btn.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  // Pause/Resume
+  let paused = false;
+  if (pauseBtn) {
+    pauseBtn.addEventListener('click', () => {
+      paused = !paused;
+      if (paused) {
+        scheduler.pause();
+        pauseBtn.textContent = '▶ Resume';
+        pauseBtn.classList.add('paused');
+      } else {
+        scheduler.resume();
+        pauseBtn.textContent = '⏸ Pause';
+        pauseBtn.classList.remove('paused');
+      }
+    });
+  }
+}

--- a/src/components/timeline.js
+++ b/src/components/timeline.js
@@ -1,0 +1,44 @@
+/**
+ * Timeline component.
+ * Visual timeline of recent round outcomes — a compact horizontal view
+ * showing success/failure streaks at a glance.
+ */
+import { fetchLogs } from '../lib/api.js';
+
+const MAX_DOTS = 30;
+
+export async function refreshTimeline() {
+  const entries = await fetchLogs();
+  if (!entries) return;
+  renderTimeline(entries);
+}
+
+function renderTimeline(entries) {
+  const container = document.getElementById('timeline');
+  if (!entries || entries.length === 0) {
+    container.innerHTML = '<p class="empty-state">No round data yet.</p>';
+    return;
+  }
+
+  const recent = entries.slice(-MAX_DOTS);
+  const totalRounds = entries.length;
+  const successes = entries.filter(e => e.exitCode === 0).length;
+  const failRate = totalRounds > 0 ? ((totalRounds - successes) / totalRounds * 100).toFixed(0) : 0;
+
+  const dots = recent.map(e => {
+    const ok = e.exitCode === 0;
+    const cls = ok ? 'timeline-dot success' : 'timeline-dot failure';
+    const time = e.timestamp ? new Date(e.timestamp).toLocaleTimeString() : '?';
+    const title = `Round ${e.round || '?'} — ${ok ? 'Success' : 'Failed'} (${e.duration || '?'}s) at ${time}`;
+    return `<span class="${cls}" title="${title}"></span>`;
+  }).join('');
+
+  container.innerHTML = `
+    <div class="timeline-track">${dots}</div>
+    <div class="timeline-stats">
+      <span>${totalRounds} rounds today</span>
+      <span>${successes} succeeded</span>
+      <span class="${failRate > 20 ? 'text-red' : ''}">${failRate}% failure rate</span>
+    </div>
+  `;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -4,199 +4,28 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FFS Squad Monitor</title>
-  <style>
-    :root {
-      --bg: #0d1117;
-      --surface: #161b22;
-      --surface-hover: #1c2128;
-      --border: #30363d;
-      --text: #e6edf3;
-      --text-muted: #8b949e;
-      --green: #3fb950;
-      --yellow: #d29922;
-      --red: #f85149;
-      --blue: #58a6ff;
-      --mono: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
-      --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-    }
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body {
-      font-family: var(--sans);
-      background: var(--bg);
-      color: var(--text);
-      min-height: 100vh;
-    }
-
-    /* Top bar */
-    .topbar {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 1rem 2rem;
-      background: var(--surface);
-      border-bottom: 1px solid var(--border);
-      position: sticky;
-      top: 0;
-      z-index: 10;
-    }
-    .topbar h1 {
-      font-size: 1.1rem;
-      font-weight: 600;
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-    }
-    .connection-status {
-      display: flex;
-      align-items: center;
-      gap: 0.4rem;
-      font-size: 0.8rem;
-      color: var(--text-muted);
-    }
-
-    .main { padding: 1.5rem 2rem 3rem; max-width: 1200px; margin: 0 auto; }
-
-    /* Section titles */
-    .section-title {
-      font-size: 0.75rem;
-      color: var(--text-muted);
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      margin-bottom: 0.75rem;
-      margin-top: 1.5rem;
-    }
-    .section-title:first-child { margin-top: 0; }
-
-    /* Cards */
-    .card {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      padding: 1.25rem;
-    }
-    .card h3 {
-      font-size: 0.85rem;
-      color: var(--text-muted);
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      margin-bottom: 0.75rem;
-    }
-
-    /* Status dot */
-    .dot {
-      display: inline-block;
-      width: 9px; height: 9px;
-      border-radius: 50%;
-      flex-shrink: 0;
-    }
-    .dot.green  { background: var(--green); }
-    .dot.yellow { background: var(--yellow); animation: pulse 1.5s infinite; }
-    .dot.red    { background: var(--red); }
-    .dot.gray   { background: var(--text-muted); }
-    @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
-
-    /* Ralph row */
-    .ralph-grid {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 1rem;
-    }
-    #heartbeat-data { font-family: var(--mono); font-size: 0.85rem; }
-    #heartbeat-data dt { color: var(--text-muted); float: left; width: 110px; clear: left; }
-    #heartbeat-data dd { margin-bottom: 0.2rem; }
-    #round-info { color: var(--text-muted); font-family: var(--mono); font-size: 0.85rem; }
-
-    /* Repos grid */
-    .repos-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-      gap: 1rem;
-    }
-    .repo-card {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      padding: 1.25rem;
-      transition: border-color 0.15s;
-    }
-    .repo-card:hover { border-color: var(--blue); }
-    .repo-header {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      margin-bottom: 0.75rem;
-    }
-    .repo-emoji { font-size: 1.3rem; }
-    .repo-name { font-weight: 600; font-size: 0.95rem; }
-    .repo-meta {
-      font-family: var(--mono);
-      font-size: 0.8rem;
-      color: var(--text-muted);
-      line-height: 1.6;
-    }
-    .repo-meta .label { color: var(--text-muted); display: inline-block; width: 70px; }
-    .repo-focus {
-      font-size: 0.82rem;
-      color: var(--text);
-      margin-bottom: 0.5rem;
-      line-height: 1.4;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-    }
-    .repo-link {
-      display: inline-block;
-      margin-top: 0.5rem;
-      font-size: 0.78rem;
-      color: var(--blue);
-      text-decoration: none;
-    }
-    .repo-link:hover { text-decoration: underline; }
-    .badge {
-      display: inline-block;
-      font-family: var(--mono);
-      font-size: 0.72rem;
-      padding: 0.15em 0.5em;
-      border-radius: 10px;
-      border: 1px solid var(--border);
-      color: var(--text-muted);
-    }
-    .badge.squad { border-color: var(--green); color: var(--green); }
-
-    /* Activity log */
-    #log-entries {
-      font-family: var(--mono);
-      font-size: 0.82rem;
-      max-height: 280px;
-      overflow-y: auto;
-    }
-    .log-entry {
-      padding: 0.25rem 0;
-      border-bottom: 1px solid var(--border);
-      color: var(--text-muted);
-    }
-
-    /* Responsive */
-    @media (max-width: 768px) {
-      .topbar { padding: 0.75rem 1rem; }
-      .main { padding: 1rem; }
-      .ralph-grid { grid-template-columns: 1fr; }
-      .repos-grid { grid-template-columns: 1fr; }
-    }
-  </style>
+  <link rel="stylesheet" href="./styles.css" />
 </head>
 <body>
 
-  <div class="topbar">
-    <h1>🖥️ FFS Squad Monitor</h1>
-    <div class="connection-status">
-      <span class="dot gray" id="conn-dot"></span>
-      <span id="conn-text">Connecting…</span>
+  <!-- Top Bar -->
+  <header class="topbar">
+    <h1>🖥️ <span class="title-text">FFS Squad Monitor</span><span class="title-short">FFS</span></h1>
+    <div class="topbar-right">
+      <div class="connection-status">
+        <span class="dot gray" id="conn-dot"></span>
+        <span id="conn-text">Connecting…</span>
+      </div>
+      <button class="settings-btn" id="settings-toggle" aria-label="Settings" aria-expanded="false" title="Refresh settings">⚙</button>
     </div>
-  </div>
+    <div class="settings-panel" id="settings-panel">
+      <label for="refresh-interval">Refresh Interval</label>
+      <select id="refresh-interval"></select>
+      <button class="pause-btn" id="pause-btn">⏸ Pause</button>
+    </div>
+  </header>
 
-  <div class="main">
+  <main class="main">
 
     <!-- Ralph Status -->
     <div class="section-title">Ralph Watch</div>
@@ -215,21 +44,36 @@
       </div>
     </div>
 
+    <!-- Timeline -->
+    <div class="section-title">Round Timeline</div>
+    <div class="card" id="timeline">
+      <p class="empty-state">No round data yet.</p>
+    </div>
+
     <!-- Repos -->
     <div class="section-title">Studio Repos</div>
     <div class="repos-grid" id="repos-grid">
-      <div class="repo-card" style="color:var(--text-muted);text-align:center;padding:3rem;">Loading repos…</div>
+      <div class="repo-card empty-state">Loading repos…</div>
     </div>
 
     <!-- Activity Log -->
     <div class="section-title">Activity Log</div>
     <div class="card">
+      <div class="log-toolbar" id="log-toolbar">
+        <button class="filter-btn active" data-filter="all">All</button>
+        <button class="filter-btn" data-filter="success">✅ Success</button>
+        <button class="filter-btn" data-filter="error">❌ Errors</button>
+      </div>
       <div id="log-entries">
-        <p style="color: var(--text-muted);">Waiting for log data…</p>
+        <p class="empty-state">Waiting for log data…</p>
       </div>
     </div>
 
-  </div>
+  </main>
+
+  <footer class="footer">
+    <a href="https://github.com/jperezdelreal/ffs-squad-monitor" target="_blank" rel="noopener">ffs-squad-monitor</a> · First Frame Studios
+  </footer>
 
   <script type="module" src="./monitor.js"></script>
 </body>

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,0 +1,56 @@
+/**
+ * API client for FFS Squad Monitor.
+ * Centralizes all fetch calls with error handling and connection tracking.
+ */
+
+const listeners = new Set();
+
+let _connected = false;
+
+export function isConnected() {
+  return _connected;
+}
+
+export function onConnectionChange(fn) {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+function setConnected(ok) {
+  if (_connected !== ok) {
+    _connected = ok;
+    listeners.forEach(fn => fn(ok));
+  }
+}
+
+async function safeFetch(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  setConnected(true);
+  return res.json();
+}
+
+export async function fetchHeartbeat() {
+  try {
+    return await safeFetch('/api/heartbeat');
+  } catch {
+    setConnected(false);
+    return null;
+  }
+}
+
+export async function fetchLogs() {
+  try {
+    return await safeFetch('/api/logs');
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchRepos() {
+  try {
+    return await safeFetch('/api/repos');
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/scheduler.js
+++ b/src/lib/scheduler.js
@@ -1,0 +1,65 @@
+/**
+ * Configurable polling scheduler.
+ * Supports changing intervals at runtime and pause/resume.
+ */
+
+export class Scheduler {
+  /** @type {Map<string, { fn: Function, interval: number, timerId: number|null }>} */
+  #tasks = new Map();
+  #paused = false;
+
+  /**
+   * Register a polling task.
+   * @param {string} id - Unique task name
+   * @param {Function} fn - Async function to call
+   * @param {number} interval - Milliseconds between calls
+   */
+  register(id, fn, interval) {
+    this.#tasks.set(id, { fn, interval, timerId: null });
+  }
+
+  /** Start all registered tasks (runs each immediately, then on interval). */
+  startAll() {
+    this.#paused = false;
+    for (const [id, task] of this.#tasks) {
+      this.#startTask(id, task);
+    }
+  }
+
+  /** Pause all polling. */
+  pause() {
+    this.#paused = true;
+    for (const task of this.#tasks.values()) {
+      if (task.timerId !== null) {
+        clearInterval(task.timerId);
+        task.timerId = null;
+      }
+    }
+  }
+
+  /** Resume polling. */
+  resume() {
+    this.startAll();
+  }
+
+  /** Update the interval for a specific task. */
+  setInterval(id, interval) {
+    const task = this.#tasks.get(id);
+    if (!task) return;
+    task.interval = interval;
+    if (!this.#paused && task.timerId !== null) {
+      clearInterval(task.timerId);
+      this.#startTask(id, task);
+    }
+  }
+
+  /** Get current interval for a task. */
+  getInterval(id) {
+    return this.#tasks.get(id)?.interval ?? null;
+  }
+
+  #startTask(id, task) {
+    task.fn();
+    task.timerId = setInterval(task.fn, task.interval);
+  }
+}

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,0 +1,29 @@
+/** Escape HTML entities to prevent XSS. */
+export function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+/** Format a duration in seconds to a human-readable string. */
+export function formatDuration(seconds) {
+  if (seconds == null) return '—';
+  if (seconds < 60) return `${seconds}s`;
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return s > 0 ? `${m}m ${s}s` : `${m}m`;
+}
+
+/** Relative time string (e.g., "2m ago", "just now"). */
+export function timeAgo(dateStr) {
+  if (!dateStr) return '—';
+  const diff = Date.now() - new Date(dateStr).getTime();
+  if (diff < 0) return 'just now';
+  const secs = Math.floor(diff / 1000);
+  if (secs < 60) return secs <= 5 ? 'just now' : `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -1,141 +1,40 @@
 /**
- * FFS Squad Monitor — Multi-repo dashboard
+ * FFS Squad Monitor — Dashboard entry point.
  *
- * Polls:
- *   /api/heartbeat — ralph-watch status (every 5s)
- *   /api/logs      — ralph-watch activity log (every 10s)
- *   /api/repos     — all studio repos status (every 30s)
+ * Component-based architecture:
+ *   - Each UI section is an independent module in src/components/
+ *   - Polling managed by a configurable Scheduler
+ *   - API layer handles connectivity tracking
  */
 
+import { Scheduler } from './lib/scheduler.js';
+import { initConnectionStatus } from './components/connection-status.js';
+import { refreshHeartbeat } from './components/heartbeat.js';
+import { refreshLogs, initLogViewer } from './components/log-viewer.js';
+import { refreshRepos } from './components/repos.js';
+import { refreshTimeline } from './components/timeline.js';
+import { initSettings } from './components/settings.js';
+
+// Default polling intervals (ms)
 const HEARTBEAT_POLL = 5000;
-const LOG_POLL = 10000;
-const REPOS_POLL = 30000;
+const LOG_POLL       = 10000;
+const REPOS_POLL     = 30000;
+const TIMELINE_POLL  = 10000;
 
-let connected = false;
+// Bootstrap
+const scheduler = new Scheduler();
 
-function setConnected(ok) {
-  connected = ok;
-  const dot = document.getElementById('conn-dot');
-  const text = document.getElementById('conn-text');
-  dot.className = ok ? 'dot green' : 'dot red';
-  text.textContent = ok ? 'Connected' : 'Disconnected';
-}
+scheduler.register('heartbeat', refreshHeartbeat, HEARTBEAT_POLL);
+scheduler.register('logs',      refreshLogs,      LOG_POLL);
+scheduler.register('repos',     refreshRepos,     REPOS_POLL);
+scheduler.register('timeline',  refreshTimeline,  TIMELINE_POLL);
 
-// ── Heartbeat ────────────────────────────────────────────
-function updateHeartbeatUI(hb) {
-  const dot = document.getElementById('ralph-dot');
-  const statusText = document.getElementById('status-text');
-  const dataEl = document.getElementById('heartbeat-data');
-  const roundInfo = document.getElementById('round-info');
+// Init components that need DOM event binding
+initConnectionStatus();
+initLogViewer();
+initSettings(scheduler);
 
-  const statusMap = { idle: 'green', running: 'yellow', error: 'red', offline: 'gray' };
-  dot.className = `dot ${statusMap[hb.status] || 'gray'}`;
-  statusText.textContent = hb.status
-    ? hb.status.charAt(0).toUpperCase() + hb.status.slice(1)
-    : 'Unknown';
+// Start polling
+scheduler.startAll();
 
-  const repos = hb.repos ? hb.repos.join(', ') : 'N/A';
-  dataEl.innerHTML = `
-    <dt>Timestamp</dt><dd>${hb.timestamp || '\u2014'}</dd>
-    <dt>Round</dt><dd>${hb.round ?? '\u2014'}</dd>
-    <dt>PID</dt><dd>${hb.pid ?? '\u2014'}</dd>
-    <dt>Interval</dt><dd>${hb.interval ? hb.interval + ' min' : '\u2014'}</dd>
-    <dt>Status</dt><dd>${hb.lastStatus || '\u2014'}</dd>
-    <dt>Duration</dt><dd>${hb.lastDuration ? hb.lastDuration + 's' : '\u2014'}</dd>
-    <dt>Failures</dt><dd>${hb.consecutiveFailures ?? 0}</dd>
-    <dt>Repos</dt><dd>${repos}</dd>
-  `;
-
-  roundInfo.textContent = `Round ${hb.round ?? '?'} · Last run: ${hb.lastStatus || 'N/A'} (${hb.lastDuration ?? '?'}s)`;
-}
-
-// ── Logs ─────────────────────────────────────────────────
-function updateLogUI(entries) {
-  const el = document.getElementById('log-entries');
-  if (!entries || entries.length === 0) {
-    el.innerHTML = '<p style="color:var(--text-muted)">No log entries yet today.</p>';
-    return;
-  }
-  el.innerHTML = entries.slice(-50).reverse().map(e => {
-    const time = e.timestamp ? new Date(e.timestamp).toLocaleTimeString() : '?';
-    const icon = e.exitCode === 0 ? '✅' : '❌';
-    const metrics = e.metrics ? ` [issues=${e.metrics.issuesClosed||0} prs=${e.metrics.prsMerged||0}]` : '';
-    return `<div class="log-entry">${icon} ${time} Round ${e.round||'?'} (${e.duration||'?'}s)${metrics}</div>`;
-  }).join('');
-}
-
-// ── Repos ────────────────────────────────────────────────
-function updateReposUI(repos) {
-  const grid = document.getElementById('repos-grid');
-  if (!repos || repos.length === 0) {
-    grid.innerHTML = '<div class="repo-card" style="color:var(--text-muted);text-align:center;padding:3rem;">No repo data available</div>';
-    return;
-  }
-
-  grid.innerHTML = repos.map(r => {
-    const focus = r.focus || 'No focus set';
-    const issues = r.openIssues !== null ? r.openIssues : '—';
-    const commit = r.lastCommit ? r.lastCommit.message : '—';
-    const sha = r.lastCommit ? r.lastCommit.sha : '';
-    const squadBadge = r.hasSquad ? '<span class="badge squad">squad</span>' : '';
-
-    return `
-      <div class="repo-card">
-        <div class="repo-header">
-          <span class="repo-emoji">${r.emoji}</span>
-          <span class="repo-name">${r.label}</span>
-          ${squadBadge}
-        </div>
-        <div class="repo-focus">${escapeHtml(focus)}</div>
-        <div class="repo-meta">
-          <span class="label">Issues</span> ${issues} open<br>
-          <span class="label">Commit</span> <code>${sha}</code> ${escapeHtml(commit)}
-        </div>
-        <a class="repo-link" href="https://github.com/${r.github}" target="_blank" rel="noopener">
-          github.com/${r.github} ↗
-        </a>
-      </div>
-    `;
-  }).join('');
-}
-
-function escapeHtml(str) {
-  const div = document.createElement('div');
-  div.textContent = str;
-  return div.innerHTML;
-}
-
-// ── Polling ──────────────────────────────────────────────
-async function pollHeartbeat() {
-  try {
-    const res = await fetch('/api/heartbeat');
-    if (res.ok) {
-      updateHeartbeatUI(await res.json());
-      setConnected(true);
-    }
-  } catch { setConnected(false); }
-}
-
-async function pollLogs() {
-  try {
-    const res = await fetch('/api/logs');
-    if (res.ok) updateLogUI(await res.json());
-  } catch { /* silent */ }
-}
-
-async function pollRepos() {
-  try {
-    const res = await fetch('/api/repos');
-    if (res.ok) updateReposUI(await res.json());
-  } catch { /* silent */ }
-}
-
-// Start all polling loops
-pollHeartbeat();
-pollLogs();
-pollRepos();
-setInterval(pollHeartbeat, HEARTBEAT_POLL);
-setInterval(pollLogs, LOG_POLL);
-setInterval(pollRepos, REPOS_POLL);
-
-console.log('[FFS Monitor] Dashboard online — polling heartbeat, logs, repos');
+console.log('[FFS Monitor] Dashboard online');

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,521 @@
+/* ── FFS Squad Monitor — Dashboard Styles ────────────────
+ * Dark theme matching GitHub aesthetic.
+ * CSS custom properties for theming.
+ * Mobile-first responsive layout.
+ * ──────────────────────────────────────────────────────── */
+
+/* ── Theme Tokens ──────────────────────────────────────── */
+:root {
+  --bg:            #0d1117;
+  --surface:       #161b22;
+  --surface-hover: #1c2128;
+  --surface-alt:   #21262d;
+  --border:        #30363d;
+  --border-light:  #3d444d;
+
+  --text:          #e6edf3;
+  --text-muted:    #8b949e;
+  --text-subtle:   #656d76;
+
+  --green:         #3fb950;
+  --green-dim:     #238636;
+  --yellow:        #d29922;
+  --red:           #f85149;
+  --red-dim:       #da3633;
+  --blue:          #58a6ff;
+  --purple:        #bc8cff;
+
+  --mono: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --radius:    8px;
+  --radius-sm: 4px;
+  --radius-lg: 12px;
+}
+
+/* ── Reset ─────────────────────────────────────────────── */
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Top Bar ───────────────────────────────────────────── */
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 2rem;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  gap: 1rem;
+}
+
+.topbar h1 {
+  font-size: 1rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+}
+
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+/* ── Connection Status ─────────────────────────────────── */
+.connection-status {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* ── Status Dot ────────────────────────────────────────── */
+.dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.dot.green  { background: var(--green); box-shadow: 0 0 6px var(--green-dim); }
+.dot.yellow { background: var(--yellow); animation: pulse 1.5s ease-in-out infinite; }
+.dot.red    { background: var(--red); box-shadow: 0 0 6px var(--red-dim); }
+.dot.gray   { background: var(--text-subtle); }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+/* ── Settings ──────────────────────────────────────────── */
+.settings-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  padding: 0.3rem 0.55rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+  line-height: 1;
+}
+.settings-btn:hover {
+  border-color: var(--blue);
+  color: var(--text);
+}
+
+.settings-panel {
+  display: none;
+  position: absolute;
+  top: 100%;
+  right: 2rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  z-index: 200;
+  min-width: 220px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+.settings-panel.open {
+  display: block;
+}
+
+.settings-panel label {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-bottom: 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.settings-panel select {
+  width: 100%;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.4rem 0.5rem;
+  font-size: 0.85rem;
+  font-family: var(--mono);
+  margin-bottom: 0.75rem;
+  cursor: pointer;
+}
+.settings-panel select:focus {
+  outline: none;
+  border-color: var(--blue);
+}
+
+.pause-btn {
+  width: 100%;
+  background: var(--surface-alt);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.45rem;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.pause-btn:hover {
+  background: var(--surface-hover);
+  border-color: var(--blue);
+}
+.pause-btn.paused {
+  border-color: var(--green);
+  color: var(--green);
+}
+
+/* ── Main Container ────────────────────────────────────── */
+.main {
+  padding: 1.5rem 2rem 3rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+/* ── Section Titles ────────────────────────────────────── */
+.section-title {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.75rem;
+  margin-top: 2rem;
+  font-weight: 600;
+}
+.section-title:first-child {
+  margin-top: 0;
+}
+
+/* ── Cards ─────────────────────────────────────────────── */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  transition: border-color 0.15s;
+}
+
+.card h3 {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+}
+
+/* ── Ralph Grid (heartbeat + round stats) ──────────────── */
+.ralph-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+#heartbeat-data {
+  font-family: var(--mono);
+  font-size: 0.82rem;
+}
+#heartbeat-data dt {
+  color: var(--text-muted);
+  float: left;
+  width: 100px;
+  clear: left;
+}
+#heartbeat-data dd {
+  margin-bottom: 0.3rem;
+}
+
+#round-info {
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 0.82rem;
+}
+
+/* ── Timeline ──────────────────────────────────────────── */
+.timeline-track {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.timeline-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  cursor: default;
+  transition: transform 0.1s;
+}
+.timeline-dot:hover {
+  transform: scale(1.3);
+}
+.timeline-dot.success {
+  background: var(--green-dim);
+}
+.timeline-dot.failure {
+  background: var(--red-dim);
+}
+
+.timeline-stats {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.78rem;
+  font-family: var(--mono);
+  color: var(--text-muted);
+}
+
+.text-red {
+  color: var(--red);
+}
+
+/* ── Repos Grid ────────────────────────────────────────── */
+.repos-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.repo-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.repo-card:hover {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 1px var(--blue);
+}
+
+.repo-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+.repo-emoji { font-size: 1.3rem; }
+.repo-name  { font-weight: 600; font-size: 0.95rem; }
+
+.repo-meta {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  line-height: 1.7;
+}
+.repo-meta .label {
+  color: var(--text-subtle);
+  display: inline-block;
+  width: 70px;
+}
+.repo-meta code {
+  background: var(--surface-alt);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.85em;
+}
+
+.repo-focus {
+  font-size: 0.82rem;
+  color: var(--text);
+  margin-bottom: 0.5rem;
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.repo-link {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--blue);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+.repo-link:hover {
+  text-decoration: underline;
+  color: var(--text);
+}
+
+.badge {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  padding: 0.15em 0.5em;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.badge.squad {
+  border-color: var(--green);
+  color: var(--green);
+}
+
+/* ── Log Viewer ────────────────────────────────────────── */
+.log-toolbar {
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.filter-btn {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  padding: 0.25rem 0.65rem;
+  font-size: 0.72rem;
+  cursor: pointer;
+  font-family: var(--sans);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.filter-btn:hover {
+  border-color: var(--blue);
+  color: var(--text);
+}
+.filter-btn.active {
+  background: var(--surface-alt);
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+#log-entries {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  max-height: 300px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+#log-entries::-webkit-scrollbar {
+  width: 6px;
+}
+#log-entries::-webkit-scrollbar-track {
+  background: transparent;
+}
+#log-entries::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+
+.log-entry {
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  transition: background 0.1s;
+}
+.log-entry:hover {
+  background: var(--surface-hover);
+}
+.log-entry.log-error {
+  color: var(--red);
+}
+
+.log-time {
+  color: var(--text-subtle);
+}
+.log-duration {
+  color: var(--text-subtle);
+}
+.log-metrics {
+  color: var(--blue);
+  font-size: 0.75rem;
+}
+
+/* ── Empty States ──────────────────────────────────────── */
+.empty-state {
+  color: var(--text-subtle);
+  text-align: center;
+  padding: 2rem;
+  font-size: 0.85rem;
+}
+
+/* ── Footer ────────────────────────────────────────────── */
+.footer {
+  text-align: center;
+  padding: 1.5rem 2rem;
+  font-size: 0.72rem;
+  color: var(--text-subtle);
+  border-top: 1px solid var(--border);
+  margin-top: 2rem;
+}
+.footer a {
+  color: var(--blue);
+  text-decoration: none;
+}
+.footer a:hover {
+  text-decoration: underline;
+}
+
+/* ── Responsive ────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .topbar {
+    padding: 0.65rem 1rem;
+  }
+  .main {
+    padding: 1rem;
+  }
+  .ralph-grid {
+    grid-template-columns: 1fr;
+  }
+  .repos-grid {
+    grid-template-columns: 1fr;
+  }
+  .timeline-stats {
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .settings-panel {
+    right: 1rem;
+    left: 1rem;
+    min-width: auto;
+  }
+}
+
+@media (max-width: 480px) {
+  .topbar h1 {
+    font-size: 0.9rem;
+  }
+  .topbar h1 .title-text {
+    display: none;
+  }
+  .topbar h1 .title-short {
+    display: inline;
+  }
+  .card {
+    padding: 1rem;
+  }
+  #heartbeat-data dt {
+    width: 80px;
+  }
+}
+
+/* Default: show full title, hide short */
+.title-short {
+  display: none;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -118,20 +118,137 @@ function ffsApiPlugin() {
         res.end(JSON.stringify(getHeartbeatResponse()));
       });
 
-      // Structured logs from ralph-watch
+      // ── Log helpers ──────────────────────────────────────
+      function listLogFiles() {
+        try {
+          if (!fs.existsSync(logsDir)) return [];
+          return fs.readdirSync(logsDir)
+            .filter(f => f.endsWith('.jsonl'))
+            .map(f => {
+              const match = f.match(/^(.+)-(\d{4}-\d{2}-\d{2})\.jsonl$/);
+              return match ? { file: f, agent: match[1], date: match[2] } : null;
+            })
+            .filter(Boolean)
+            .sort((a, b) => b.date.localeCompare(a.date));
+        } catch { return []; }
+      }
+
+      function readLogEntries(agent, date) {
+        const filename = `${agent}-${date}.jsonl`;
+        const filePath = path.join(logsDir, filename);
+        try {
+          if (!fs.existsSync(filePath)) return [];
+          const raw = fs.readFileSync(filePath, 'utf-8').replace(/^\uFEFF/, '');
+          if (!raw.trim()) return [];
+          return raw.trim().split('\n').map(line => {
+            try {
+              const entry = JSON.parse(line);
+              // Derive level from exitCode/status
+              entry._agent = agent;
+              entry._level = entry.exitCode === 0 ? 'info' : 'error';
+              if (entry.consecutiveFailures > 0 && entry.exitCode === 0) entry._level = 'warn';
+              return entry;
+            } catch { return null; }
+          }).filter(Boolean);
+        } catch { return []; }
+      }
+
+      // List available log files (for date/agent pickers)
+      server.middlewares.use('/api/logs/files', (req, res) => {
+        const files = listLogFiles();
+        const agents = [...new Set(files.map(f => f.agent))];
+        const dates = [...new Set(files.map(f => f.date))];
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ agents, dates, files }));
+      });
+
+      // SSE endpoint — streams new log entries in real time
+      server.middlewares.use('/api/logs/stream', (req, res) => {
+        res.setHeader('Content-Type', 'text/event-stream');
+        res.setHeader('Cache-Control', 'no-cache');
+        res.setHeader('Connection', 'keep-alive');
+        res.setHeader('X-Accel-Buffering', 'no');
+        res.flushHeaders?.();
+        // Track file sizes so we only send new lines
+        const fileSizes = new Map();
+
+        function scanAndSend() {
+          try {
+            if (!fs.existsSync(logsDir)) return;
+            const files = fs.readdirSync(logsDir).filter(f => f.endsWith('.jsonl'));
+            for (const file of files) {
+              const filePath = path.join(logsDir, file);
+              const match = file.match(/^(.+)-(\d{4}-\d{2}-\d{2})\.jsonl$/);
+              if (!match) continue;
+              const agent = match[1];
+              let stat;
+              try { stat = fs.statSync(filePath); } catch { continue; }
+              const prevSize = fileSizes.get(file) || 0;
+              if (stat.size > prevSize) {
+                // Read only new bytes
+                const fd = fs.openSync(filePath, 'r');
+                const buf = Buffer.alloc(stat.size - prevSize);
+                fs.readSync(fd, buf, 0, buf.length, prevSize);
+                fs.closeSync(fd);
+                const newContent = buf.toString('utf-8').replace(/^\uFEFF/, '');
+                const lines = newContent.trim().split('\n').filter(l => l.trim());
+                for (const line of lines) {
+                  try {
+                    const entry = JSON.parse(line);
+                    entry._agent = agent;
+                    entry._level = entry.exitCode === 0 ? 'info' : 'error';
+                    if (entry.consecutiveFailures > 0 && entry.exitCode === 0) entry._level = 'warn';
+                    res.write(`data: ${JSON.stringify(entry)}\n\n`);
+                  } catch { /* skip malformed lines */ }
+                }
+              }
+              fileSizes.set(file, stat.size);
+            }
+          } catch { /* directory gone or unreadable */ }
+        }
+
+        // Send all existing entries on connect
+        scanAndSend();
+
+        // Watch for new entries
+        let watcher;
+        try {
+          if (fs.existsSync(logsDir)) {
+            watcher = fs.watch(logsDir, { persistent: false }, () => {
+              scanAndSend();
+            });
+            watcher.on('error', () => {});
+          }
+        } catch { /* no watcher */ }
+
+        // Keepalive ping every 15s
+        const keepalive = setInterval(() => {
+          try { res.write(': keepalive\n\n'); } catch { /* closed */ }
+        }, 15000);
+
+        req.on('close', () => {
+          clearInterval(keepalive);
+          if (watcher) watcher.close();
+        });
+      });
+
+      // Structured logs — supports ?date=YYYY-MM-DD&agent=name query params
       server.middlewares.use('/api/logs', (req, res) => {
         try {
-          const today = new Date().toISOString().slice(0, 10);
-          const logFile = path.join(logsDir, `ralph-${today}.jsonl`);
-          if (fs.existsSync(logFile)) {
-            const lines = fs.readFileSync(logFile, 'utf-8').trim().split('\n');
-            const entries = lines.map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
-            res.setHeader('Content-Type', 'application/json');
-            res.end(JSON.stringify(entries));
-          } else {
-            res.setHeader('Content-Type', 'application/json');
-            res.end('[]');
+          const url = new URL(req.url, `http://${req.headers.host}`);
+          const date = url.searchParams.get('date') || new Date().toISOString().slice(0, 10);
+          const agentFilter = url.searchParams.get('agent');
+
+          const logFiles = listLogFiles().filter(f => f.date === date);
+          let entries = [];
+          for (const f of logFiles) {
+            if (agentFilter && f.agent !== agentFilter) continue;
+            entries = entries.concat(readLogEntries(f.agent, f.date));
           }
+          // Sort by timestamp
+          entries.sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify(entries));
         } catch {
           res.statusCode = 500;
           res.end(JSON.stringify({ error: 'Failed to read logs' }));


### PR DESCRIPTION
Implements the main dashboard layout with component-based structure.

## Changes

### Architecture
- **Component-based structure**: Refactored monolithic `monitor.js` into 6 independent modules under `src/components/` (heartbeat, log-viewer, repos, timeline, settings, connection-status)
- **Shared libraries**: `src/lib/api.js` (centralized fetch + connectivity), `src/lib/scheduler.js` (configurable polling), `src/lib/util.js` (escapeHtml, timeAgo, formatDuration)
- **External stylesheet**: Extracted all inline CSS to `src/styles.css` with CSS custom properties for theming

### UI Components
- **Heartbeat card** — Ralph-watch status with colored dot, relative timestamps ("2m ago"), metadata fields
- **Round timeline** — Compact dot chart showing success/failure streaks, hover tooltips, aggregate stats
- **Log viewer** — Filterable log (All / Success / Errors) with styled entries and custom scrollbar
- **Repos grid** — Auto-fill responsive cards with hover glow, squad badge, commit info
- **Connection status** — Live indicator in top bar with reactive dot color
- **Settings panel** — Configurable refresh interval (5s/10s/30s/1m), pause/resume polling

### Design
- Dark theme matching GitHub aesthetic (`--bg: #0d1117`, `--surface: #161b22`, etc.)
- Responsive grid layout with breakpoints at 768px and 480px
- CSS custom properties for all colors, fonts, and spacing
- Smooth transitions, hover states, and scroll styling

Closes #4