### PR TITLE
feat: GitHub Actions status integration

### DIFF
--- a/src/components/workflows.js
+++ b/src/components/workflows.js
@@ -1,0 +1,75 @@
+/**
+ * Workflows component.
+ * Shows GitHub Actions workflow run status for each repo
+ * with color-coded badges and links to GitHub.
+ */
+import { fetchWorkflows } from '../lib/api.js';
+import { escapeHtml, timeAgo } from '../lib/util.js';
+
+export async function refreshWorkflows() {
+  const data = await fetchWorkflows();
+  if (!data) return;
+  renderWorkflows(data);
+}
+
+/**
+ * Map workflow conclusion/status to display info.
+ */
+function getStatusInfo(status, conclusion) {
+  if (status === 'in_progress' || status === 'queued') {
+    return { label: 'In Progress', cls: 'wf-in-progress', icon: '🔄' };
+  }
+  switch (conclusion) {
+    case 'success':    return { label: 'Success',   cls: 'wf-success',   icon: '✅' };
+    case 'failure':    return { label: 'Failed',    cls: 'wf-failure',   icon: '❌' };
+    case 'cancelled':  return { label: 'Cancelled', cls: 'wf-cancelled', icon: '⏹️' };
+    case 'skipped':    return { label: 'Skipped',   cls: 'wf-skipped',   icon: '⏭️' };
+    default:           return { label: status || 'Unknown', cls: 'wf-unknown', icon: '❓' };
+  }
+}
+
+function renderWorkflows(repos) {
+  const container = document.getElementById('workflows-grid');
+  if (!repos || repos.length === 0) {
+    container.innerHTML = '<div class="empty-state">No workflow data available</div>';
+    return;
+  }
+
+  container.innerHTML = repos.map(repo => {
+    if (repo.workflows.length === 0) {
+      const msg = repo.error ? escapeHtml(repo.error) : 'No workflows found';
+      return `
+        <div class="wf-repo-card">
+          <div class="wf-repo-header">
+            <span class="repo-emoji">${repo.emoji}</span>
+            <span class="repo-name">${escapeHtml(repo.label)}</span>
+          </div>
+          <p class="wf-empty">${msg}</p>
+        </div>`;
+    }
+
+    const rows = repo.workflows.map(wf => {
+      const info = getStatusInfo(wf.status, wf.conclusion);
+      const ago = timeAgo(wf.updatedAt);
+      const branch = wf.branch ? escapeHtml(wf.branch) : '';
+      const url = wf.url || `https://github.com/${repo.github}/actions`;
+
+      return `
+        <a class="wf-run" href="${url}" target="_blank" rel="noopener" title="${escapeHtml(wf.workflow)} on ${branch} — ${info.label}">
+          <span class="wf-badge ${info.cls}">${info.icon} ${info.label}</span>
+          <span class="wf-name">${escapeHtml(wf.workflow)}</span>
+          <span class="wf-meta">${branch} · ${ago}</span>
+        </a>`;
+    }).join('');
+
+    return `
+      <div class="wf-repo-card">
+        <div class="wf-repo-header">
+          <span class="repo-emoji">${repo.emoji}</span>
+          <span class="repo-name">${escapeHtml(repo.label)}</span>
+          <a class="wf-actions-link" href="https://github.com/${repo.github}/actions" target="_blank" rel="noopener">Actions ↗</a>
+        </div>
+        <div class="wf-runs">${rows}</div>
+      </div>`;
+  }).join('');
+}

--- a/src/index.html
+++ b/src/index.html
@@ -56,6 +56,12 @@
       <div class="repo-card empty-state">Loading repos…</div>
     </div>
 
+    <!-- GitHub Actions -->
+    <div class="section-title">GitHub Actions</div>
+    <div class="workflows-grid" id="workflows-grid">
+      <div class="empty-state">Loading workflows…</div>
+    </div>
+
     <!-- Log Viewer -->
     <div class="section-title">Log Viewer <span class="log-count" id="log-count"></span></div>
     <div class="card">

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -62,3 +62,11 @@ export async function fetchRepos() {
     return null;
   }
 }
+
+export async function fetchWorkflows() {
+  try {
+    return await safeFetch('/api/workflows');
+  } catch {
+    return null;
+  }
+}

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -12,6 +12,7 @@ import { initConnectionStatus } from './components/connection-status.js';
 import { refreshHeartbeat } from './components/heartbeat.js';
 import { refreshLogs, initLogViewer } from './components/log-viewer.js';
 import { refreshRepos } from './components/repos.js';
+import { refreshWorkflows } from './components/workflows.js';
 import { refreshTimeline, initTimeline } from './components/timeline.js';
 import { initSettings } from './components/settings.js';
 
@@ -19,6 +20,7 @@ import { initSettings } from './components/settings.js';
 const HEARTBEAT_POLL = 5000;
 const LOG_POLL       = 10000;
 const REPOS_POLL     = 30000;
+const WORKFLOWS_POLL = 60000;
 const TIMELINE_POLL  = 10000;
 
 // Bootstrap
@@ -26,8 +28,9 @@ const scheduler = new Scheduler();
 
 scheduler.register('heartbeat', refreshHeartbeat, HEARTBEAT_POLL);
 scheduler.register('logs',      refreshLogs,      LOG_POLL);
-scheduler.register('repos',     refreshRepos,     REPOS_POLL);
-scheduler.register('timeline',  refreshTimeline,  TIMELINE_POLL);
+scheduler.register('repos',      refreshRepos,      REPOS_POLL);
+scheduler.register('workflows', refreshWorkflows,  WORKFLOWS_POLL);
+scheduler.register('timeline',  refreshTimeline,   TIMELINE_POLL);
 
 // Init components that need DOM event binding
 initConnectionStatus();

--- a/src/styles.css
+++ b/src/styles.css
@@ -663,6 +663,115 @@ body {
   font-size: 0.85rem;
 }
 
+/* ── Workflows Grid ─────────────────────────────────────── */
+.workflows-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.wf-repo-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  transition: border-color 0.15s;
+}
+
+.wf-repo-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.wf-actions-link {
+  margin-left: auto;
+  font-size: 0.72rem;
+  color: var(--blue);
+  text-decoration: none;
+}
+.wf-actions-link:hover {
+  text-decoration: underline;
+}
+
+.wf-runs {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.wf-run {
+  display: grid;
+  grid-template-columns: 110px 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.4rem 0.55rem;
+  border-radius: var(--radius-sm);
+  text-decoration: none;
+  color: var(--text);
+  transition: background 0.1s;
+}
+.wf-run:hover {
+  background: var(--surface-hover);
+}
+
+.wf-badge {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  padding: 0.2em 0.55em;
+  border-radius: 10px;
+  text-align: center;
+  white-space: nowrap;
+  border: 1px solid var(--border);
+}
+.wf-badge.wf-success {
+  border-color: var(--green-dim);
+  color: var(--green);
+  background: rgba(63, 185, 80, 0.08);
+}
+.wf-badge.wf-failure {
+  border-color: var(--red-dim);
+  color: var(--red);
+  background: rgba(248, 81, 73, 0.08);
+}
+.wf-badge.wf-in-progress {
+  border-color: var(--yellow);
+  color: var(--yellow);
+  background: rgba(210, 153, 34, 0.08);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+.wf-badge.wf-cancelled {
+  color: var(--text-muted);
+}
+.wf-badge.wf-skipped {
+  color: var(--text-muted);
+}
+.wf-badge.wf-unknown {
+  color: var(--text-subtle);
+}
+
+.wf-name {
+  font-size: 0.82rem;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wf-meta {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.wf-empty {
+  font-size: 0.82rem;
+  color: var(--text-subtle);
+  padding: 0.5rem 0;
+}
+
 /* ── Footer ────────────────────────────────────────────── */
 .footer {
   text-align: center;
@@ -692,6 +801,9 @@ body {
     grid-template-columns: 1fr;
   }
   .repos-grid {
+    grid-template-columns: 1fr;
+  }
+  .workflows-grid {
     grid-template-columns: 1fr;
   }
   .timeline-summary {

--- a/vite.config.js
+++ b/vite.config.js
@@ -50,6 +50,67 @@ function getLastCommit(repoDir) {
   } catch { return null; }
 }
 
+// ── GitHub Actions workflow status (cached) ───────────────
+const WORKFLOW_CACHE_TTL = 120_000; // 2 minutes
+let workflowCache = null;
+let workflowCacheTime = 0;
+
+function fetchWorkflowRuns() {
+  // Return cache if fresh
+  if (workflowCache && Date.now() - workflowCacheTime < WORKFLOW_CACHE_TTL) {
+    return workflowCache;
+  }
+
+  const results = [];
+  for (const repo of REPOS) {
+    try {
+      const out = execSync(
+        `gh run list --repo ${repo.github} --limit 8 --json workflowName,status,conclusion,headBranch,updatedAt,databaseId,url`,
+        { timeout: 15000, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
+      );
+      const runs = JSON.parse(out);
+
+      // Group by workflow name, keep only the latest run per workflow
+      const byWorkflow = new Map();
+      for (const run of runs) {
+        const name = run.workflowName;
+        if (!byWorkflow.has(name)) {
+          byWorkflow.set(name, {
+            workflow: name,
+            status: run.status,
+            conclusion: run.conclusion,
+            branch: run.headBranch,
+            updatedAt: run.updatedAt,
+            runId: run.databaseId,
+            url: run.url || `https://github.com/${repo.github}/actions`,
+          });
+        }
+      }
+
+      results.push({
+        repo: repo.id,
+        label: repo.label,
+        emoji: repo.emoji,
+        github: repo.github,
+        workflows: [...byWorkflow.values()],
+      });
+    } catch {
+      results.push({
+        repo: repo.id,
+        label: repo.label,
+        emoji: repo.emoji,
+        github: repo.github,
+        workflows: [],
+        error: 'Failed to fetch workflows',
+      });
+    }
+  }
+
+  workflowCache = results;
+  workflowCacheTime = Date.now();
+  return results;
+}
+
 function ffsApiPlugin() {
   const ffsRoot = path.resolve(__dirname, '..', 'FirstFrameStudios');
   const heartbeatPath = process.env.FFS_HEARTBEAT_PATH
@@ -279,6 +340,7 @@ function ffsApiPlugin() {
             : 0;
           const maxDuration = durations.length > 0 ? Math.max(...durations) : 0;
 
+          // Read heartbeat for current status
           const hb = getHeartbeatResponse();
 
           res.setHeader('Content-Type', 'application/json');
@@ -326,6 +388,13 @@ function ffsApiPlugin() {
           res.statusCode = 500;
           res.end(JSON.stringify({ error: 'Failed to read logs' }));
         }
+      });
+
+      // GitHub Actions workflow runs (cached)
+      server.middlewares.use('/api/workflows', (req, res) => {
+        const data = fetchWorkflowRuns();
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify(data));
       });
 
       // All repos status


### PR DESCRIPTION
Shows latest workflow run status with color-coded badges for all FFS repos.

## Changes
- **Backend**: \/api/workflows\ endpoint in Vite plugin using \gh run list\ with 2-minute cache to avoid rate limits
- **Frontend**: \workflows.js\ component rendering per-repo cards with workflow name, status badge, branch, and time ago
- **Styles**: Color-coded badges (green=success, red=failure, yellow=in-progress, muted=cancelled/skipped)
- **Polling**: 60s interval via scheduler, configurable through settings

Target repos: FirstFrameStudios, ComeRosquillas, flora, ffs-squad-monitor

Closes #5