### PR TITLE
feat: agent activity timeline — swim-lane visualization

### DIFF
--- a/src/components/timeline.js
+++ b/src/components/timeline.js
@@ -1,44 +1,158 @@
 /**
- * Timeline component.
- * Visual timeline of recent round outcomes — a compact horizontal view
- * showing success/failure streaks at a glance.
+ * Timeline component — swim-lane visualization.
+ * Shows agent activity as horizontal bars, color-coded by outcome,
+ * with expandable round details on click.
  */
-import { fetchLogs } from '../lib/api.js';
+import { fetchTimeline } from '../lib/api.js';
+import { formatDuration, escapeHtml } from '../lib/util.js';
 
-const MAX_DOTS = 30;
+let expandedRoundId = null;
 
 export async function refreshTimeline() {
-  const entries = await fetchLogs();
-  if (!entries) return;
-  renderTimeline(entries);
+  const data = await fetchTimeline();
+  if (!data) return;
+  renderTimeline(data);
 }
 
-function renderTimeline(entries) {
+export function initTimeline() {
   const container = document.getElementById('timeline');
-  if (!entries || entries.length === 0) {
+  if (!container) return;
+  container.addEventListener('click', handleTimelineClick);
+}
+
+function handleTimelineClick(e) {
+  const bar = e.target.closest('[data-round-id]');
+  if (!bar) return;
+
+  const roundId = bar.dataset.roundId;
+  expandedRoundId = expandedRoundId === roundId ? null : roundId;
+
+  // Update active state on all bars
+  const allBars = document.querySelectorAll('.swim-bar');
+  allBars.forEach(b => b.classList.toggle('active', b.dataset.roundId === expandedRoundId));
+
+  // Toggle detail panel
+  const detailPanel = document.getElementById('timeline-detail');
+  if (expandedRoundId && bar._roundData) {
+    renderDetail(detailPanel, bar._roundData);
+    detailPanel.classList.add('open');
+  } else if (detailPanel) {
+    detailPanel.classList.remove('open');
+  }
+}
+
+function renderTimeline(data) {
+  const container = document.getElementById('timeline');
+  if (!data.rounds || data.rounds.length === 0) {
     container.innerHTML = '<p class="empty-state">No round data yet.</p>';
     return;
   }
 
-  const recent = entries.slice(-MAX_DOTS);
-  const totalRounds = entries.length;
-  const successes = entries.filter(e => e.exitCode === 0).length;
-  const failRate = totalRounds > 0 ? ((totalRounds - successes) / totalRounds * 100).toFixed(0) : 0;
+  const { rounds, agents, summary } = data;
+  const maxDur = summary.maxDuration || 1;
 
-  const dots = recent.map(e => {
-    const ok = e.exitCode === 0;
-    const cls = ok ? 'timeline-dot success' : 'timeline-dot failure';
-    const time = e.timestamp ? new Date(e.timestamp).toLocaleTimeString() : '?';
-    const title = `Round ${e.round || '?'} — ${ok ? 'Success' : 'Failed'} (${e.duration || '?'}s) at ${time}`;
-    return `<span class="${cls}" title="${title}"></span>`;
-  }).join('');
+  // Group rounds by agent for swim lanes
+  const lanes = new Map();
+  for (const agent of agents) {
+    lanes.set(agent, rounds.filter(r => r.agent === agent));
+  }
 
-  container.innerHTML = `
-    <div class="timeline-track">${dots}</div>
-    <div class="timeline-stats">
-      <span>${totalRounds} rounds today</span>
-      <span>${successes} succeeded</span>
-      <span class="${failRate > 20 ? 'text-red' : ''}">${failRate}% failure rate</span>
+  const failRate = summary.total > 0
+    ? Math.round((summary.error / summary.total) * 100)
+    : 0;
+
+  let html = `
+    <div class="timeline-summary">
+      <span class="tl-stat"><strong>${summary.total}</strong> rounds</span>
+      <span class="tl-stat tl-success"><span class="dot green"></span> ${summary.success} ok</span>
+      <span class="tl-stat tl-error"><span class="dot red"></span> ${summary.error} failed</span>
+      <span class="tl-stat">avg ${formatDuration(Math.round(summary.avgDuration))}</span>
+      <span class="tl-stat ${failRate > 20 ? 'text-red' : ''}">${failRate}% fail</span>
+    </div>
+  `;
+
+  // Swim lanes per agent
+  for (const [agent, agentRounds] of lanes) {
+    html += `<div class="swim-lane">`;
+    html += `<div class="swim-lane-label">${escapeHtml(agent)}</div>`;
+    html += `<div class="swim-lane-track">`;
+
+    agentRounds.forEach((r, i) => {
+      const widthPct = Math.max(2, (r.duration / maxDur) * 100);
+      const outcomeClass = r.outcome === 'success' ? 'bar-success' : 'bar-error';
+      const roundId = `${r.agent}-${i}`;
+      const isActive = expandedRoundId === roundId ? ' active' : '';
+      const time = r.timestamp ? new Date(r.timestamp).toLocaleTimeString() : '?';
+      const title = `Round ${r.round} - ${r.outcome} (${formatDuration(Math.round(r.duration))}) at ${time}`;
+
+      html += `<div class="swim-bar ${outcomeClass}${isActive}" data-round-id="${roundId}" title="${escapeHtml(title)}" style="width:${widthPct.toFixed(1)}%">`;
+      html += `<span class="swim-bar-label">R${r.round}</span>`;
+      html += `</div>`;
+    });
+
+    html += `</div></div>`;
+  }
+
+  // Time axis
+  const firstTs = rounds[0]?.timestamp;
+  const lastTs = rounds[rounds.length - 1]?.timestamp;
+  if (firstTs && lastTs) {
+    const startTime = new Date(firstTs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    const endTime = new Date(lastTs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    html += `<div class="timeline-axis"><span>${startTime}</span><span>duration scaled</span><span>${endTime}</span></div>`;
+  }
+
+  // Detail panel
+  html += `<div id="timeline-detail" class="timeline-detail ${expandedRoundId ? 'open' : ''}"></div>`;
+
+  container.innerHTML = html;
+
+  // Attach round data to bar DOM elements for click handler
+  container.querySelectorAll('.swim-lane').forEach(laneEl => {
+    const agentName = laneEl.querySelector('.swim-lane-label')?.textContent;
+    const agentRounds = lanes.get(agentName) || [];
+    laneEl.querySelectorAll('.swim-bar').forEach((barEl, idx) => {
+      if (agentRounds[idx]) barEl._roundData = agentRounds[idx];
+    });
+  });
+
+  // Re-render expanded detail if still active
+  if (expandedRoundId) {
+    const activeBar = container.querySelector(`[data-round-id="${expandedRoundId}"]`);
+    const detailPanel = document.getElementById('timeline-detail');
+    if (activeBar?._roundData && detailPanel) {
+      renderDetail(detailPanel, activeBar._roundData);
+    }
+  }
+}
+
+function renderDetail(panel, round) {
+  if (!panel) return;
+  const time = round.timestamp ? new Date(round.timestamp).toLocaleString() : 'Unknown';
+  const outcomeIcon = round.outcome === 'success' ? '✅' : '❌';
+  const m = round.metrics || {};
+
+  panel.innerHTML = `
+    <div class="detail-header">
+      <span class="detail-title">${outcomeIcon} Round ${round.round}</span>
+      <span class="detail-agent">${escapeHtml(round.agent)}</span>
+    </div>
+    <div class="detail-grid">
+      <div class="detail-item"><span class="detail-label">Time</span><span>${time}</span></div>
+      <div class="detail-item"><span class="detail-label">Duration</span><span>${formatDuration(Math.round(round.duration))}</span></div>
+      <div class="detail-item"><span class="detail-label">Status</span><span>${round.status || 'N/A'}</span></div>
+      <div class="detail-item"><span class="detail-label">Exit Code</span><span class="${round.exitCode !== 0 ? 'text-red' : ''}">${round.exitCode}</span></div>
+      <div class="detail-item"><span class="detail-label">Phase</span><span>${round.phase || 'N/A'}</span></div>
+      <div class="detail-item"><span class="detail-label">Failures</span><span class="${round.consecutiveFailures > 0 ? 'text-red' : ''}">${round.consecutiveFailures}</span></div>
+    </div>
+    <div class="detail-metrics">
+      <span class="detail-label">Metrics</span>
+      <div class="detail-metrics-row">
+        <span>PRs merged: <strong>${m.prsMerged ?? 0}</strong></span>
+        <span>PRs opened: <strong>${m.prsOpened ?? 0}</strong></span>
+        <span>Issues closed: <strong>${m.issuesClosed ?? 0}</strong></span>
+        <span>Commits: <strong>${m.commitsCount ?? 0}</strong></span>
+      </div>
     </div>
   `;
 }

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -47,6 +47,14 @@ export async function fetchLogs() {
   }
 }
 
+export async function fetchTimeline() {
+  try {
+    return await safeFetch('/api/timeline');
+  } catch {
+    return null;
+  }
+}
+
 export async function fetchRepos() {
   try {
     return await safeFetch('/api/repos');

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -12,7 +12,7 @@ import { initConnectionStatus } from './components/connection-status.js';
 import { refreshHeartbeat } from './components/heartbeat.js';
 import { refreshLogs, initLogViewer } from './components/log-viewer.js';
 import { refreshRepos } from './components/repos.js';
-import { refreshTimeline } from './components/timeline.js';
+import { refreshTimeline, initTimeline } from './components/timeline.js';
 import { initSettings } from './components/settings.js';
 
 // Default polling intervals (ms)
@@ -32,6 +32,7 @@ scheduler.register('timeline',  refreshTimeline,  TIMELINE_POLL);
 // Init components that need DOM event binding
 initConnectionStatus();
 initLogViewer();
+initTimeline();
 initSettings(scheduler);
 
 // Start polling

--- a/src/styles.css
+++ b/src/styles.css
@@ -252,36 +252,182 @@ body {
 }
 
 /* ── Timeline ──────────────────────────────────────────── */
-.timeline-track {
+
+/* Summary stats row */
+.timeline-summary {
   display: flex;
-  gap: 4px;
   flex-wrap: wrap;
+  gap: 1.25rem;
+  padding-bottom: 0.75rem;
+  margin-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  align-items: center;
+}
+.tl-stat {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+.tl-stat strong {
+  color: var(--text);
+}
+
+/* Swim lanes */
+.swim-lane {
+  display: flex;
+  align-items: stretch;
+  margin-bottom: 0.5rem;
+  min-height: 32px;
+}
+.swim-lane-label {
+  width: 70px;
+  flex-shrink: 0;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  display: flex;
+  align-items: center;
+  padding-right: 0.5rem;
+}
+.swim-lane-track {
+  flex: 1;
+  display: flex;
+  gap: 3px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* Individual bars */
+.swim-bar {
+  height: 28px;
+  min-width: 24px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.1s, box-shadow 0.15s, filter 0.15s;
+  overflow: hidden;
+}
+.swim-bar:hover {
+  transform: scaleY(1.15);
+  filter: brightness(1.2);
+  z-index: 2;
+}
+.swim-bar.active {
+  transform: scaleY(1.2);
+  box-shadow: 0 0 0 2px var(--blue), 0 2px 8px rgba(88, 166, 255, 0.3);
+  z-index: 3;
+}
+.swim-bar.bar-success {
+  background: linear-gradient(135deg, var(--green-dim), var(--green));
+}
+.swim-bar.bar-error {
+  background: linear-gradient(135deg, var(--red-dim), var(--red));
+}
+.swim-bar.bar-skipped {
+  background: linear-gradient(135deg, #6e5b00, var(--yellow));
+}
+.swim-bar-label {
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  color: rgba(255, 255, 255, 0.85);
+  pointer-events: none;
+  white-space: nowrap;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+/* Time axis */
+.timeline-axis {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border);
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  color: var(--text-subtle);
+}
+
+/* Expandable detail panel */
+.timeline-detail {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.25s ease, padding 0.25s ease, margin 0.25s ease;
+  background: var(--bg);
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  margin-top: 0;
+  padding: 0 1rem;
+}
+.timeline-detail.open {
+  max-height: 300px;
+  padding: 1rem;
+  margin-top: 0.75rem;
+  border-color: var(--border);
+}
+
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin-bottom: 0.75rem;
 }
-
-.timeline-dot {
-  width: 14px;
-  height: 14px;
-  border-radius: 3px;
-  cursor: default;
-  transition: transform 0.1s;
+.detail-title {
+  font-weight: 600;
+  font-size: 0.92rem;
 }
-.timeline-dot:hover {
-  transform: scale(1.3);
-}
-.timeline-dot.success {
-  background: var(--green-dim);
-}
-.timeline-dot.failure {
-  background: var(--red-dim);
-}
-
-.timeline-stats {
-  display: flex;
-  gap: 1.5rem;
-  font-size: 0.78rem;
+.detail-agent {
   font-family: var(--mono);
+  font-size: 0.75rem;
   color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.detail-label {
+  font-size: 0.68rem;
+  color: var(--text-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-family: var(--mono);
+}
+.detail-item span:last-child {
+  font-family: var(--mono);
+  font-size: 0.82rem;
+}
+
+.detail-metrics {
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border);
+}
+.detail-metrics-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin-top: 0.35rem;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+.detail-metrics-row strong {
+  color: var(--blue);
 }
 
 .text-red {
@@ -486,7 +632,17 @@ body {
   .repos-grid {
     grid-template-columns: 1fr;
   }
-  .timeline-stats {
+  .timeline-summary {
+    gap: 0.75rem;
+  }
+  .swim-lane-label {
+    width: 50px;
+    font-size: 0.65rem;
+  }
+  .detail-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .detail-metrics-row {
     flex-direction: column;
     gap: 0.3rem;
   }

--- a/vite.config.js
+++ b/vite.config.js
@@ -232,6 +232,66 @@ function ffsApiPlugin() {
         });
       });
 
+      // ── Timeline endpoint ────────────────────────────────
+      server.middlewares.use('/api/timeline', (req, res) => {
+        try {
+          const url = new URL(req.url, `http://${req.headers.host}`);
+          const date = url.searchParams.get('date') || new Date().toISOString().slice(0, 10);
+          const logFiles = listLogFiles().filter(f => f.date === date);
+          let entries = [];
+          for (const f of logFiles) {
+            entries = entries.concat(readLogEntries(f.agent, f.date));
+          }
+          entries.sort((a, b) => (a.timestamp || '').localeCompare(b.timestamp || ''));
+
+          const agents = [...new Set(entries.map(e => e._agent))];
+          const rounds = entries.map(e => ({
+            agent: e._agent,
+            round: e.round,
+            timestamp: e.timestamp,
+            duration: e.duration ?? 0,
+            outcome: e.exitCode === 0 ? 'success' : 'error',
+            exitCode: e.exitCode,
+            status: e.status,
+            phase: e.phase,
+            consecutiveFailures: e.consecutiveFailures ?? 0,
+            metrics: e.metrics || {},
+          }));
+
+          const successes = rounds.filter(r => r.outcome === 'success').length;
+          const errors = rounds.filter(r => r.outcome === 'error').length;
+          const durations = rounds.map(r => r.duration).filter(d => d > 0);
+          const avgDuration = durations.length > 0
+            ? Math.round((durations.reduce((a, b) => a + b, 0) / durations.length) * 10) / 10
+            : 0;
+          const maxDuration = durations.length > 0 ? Math.max(...durations) : 0;
+
+          const hb = getHeartbeatResponse();
+
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({
+            date,
+            agents,
+            rounds,
+            heartbeat: {
+              status: hb.status,
+              round: hb.round,
+              lastStatus: hb.lastStatus,
+            },
+            summary: {
+              total: rounds.length,
+              success: successes,
+              error: errors,
+              avgDuration,
+              maxDuration,
+            },
+          }));
+        } catch {
+          res.statusCode = 500;
+          res.end(JSON.stringify({ error: 'Failed to build timeline' }));
+        }
+      });
+
       // Structured logs — supports ?date=YYYY-MM-DD&agent=name query params
       server.middlewares.use('/api/logs', (req, res) => {
         try {


### PR DESCRIPTION
Implements timeline view of ralph-watch rounds with color-coded outcomes.

## Changes
- **Backend**: New \/api/timeline\ endpoint that reads structured logs and heartbeat data, returns timeline-specific data with agent grouping, round details, and computed summary stats (success/error counts, avg/max duration)
- **Frontend**: Complete rewrite of timeline component from basic dot view to swim-lane visualization — horizontal bars per agent, width scaled by duration, color-coded green (success) / red (error)
- **Interactivity**: Click any round bar to expand a detail panel showing timestamp, duration, status, exit code, phase, consecutive failures, and metrics (PRs merged/opened, issues closed, commits)
- **CSS**: Full dark-theme swim-lane styles with gradient bars, hover/active states, animated detail panel expand, responsive breakpoints
- **Integration**: Timeline polls every 10s via existing Scheduler, uses dedicated \etchTimeline\ API function

Closes #3