### PR TITLE
feat: timeline shows last 10 rounds + 'Show last' filter (#14)

### DIFF
--- a/src/components/timeline.js
+++ b/src/components/timeline.js
@@ -6,11 +6,28 @@
 import { fetchTimeline } from '../lib/api.js';
 import { formatDuration, escapeHtml } from '../lib/util.js';
 
+const STORAGE_KEY = 'ffs-timeline-limit';
+const LIMIT_OPTIONS = [10, 20, 30, 50, 'All'];
+const DEFAULT_LIMIT = 10;
+
 let expandedRoundId = null;
+let cachedData = null;
+
+function getLimit() {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === 'All') return 'All';
+  const n = parseInt(stored, 10);
+  return LIMIT_OPTIONS.includes(n) ? n : DEFAULT_LIMIT;
+}
+
+function setLimit(value) {
+  localStorage.setItem(STORAGE_KEY, value);
+}
 
 export async function refreshTimeline() {
   const data = await fetchTimeline();
   if (!data) return;
+  cachedData = data;
   renderTimeline(data);
 }
 
@@ -18,6 +35,15 @@ export function initTimeline() {
   const container = document.getElementById('timeline');
   if (!container) return;
   container.addEventListener('click', handleTimelineClick);
+
+  const select = document.getElementById('timeline-limit');
+  if (select) {
+    select.value = String(getLimit());
+    select.addEventListener('change', () => {
+      setLimit(select.value);
+      if (cachedData) renderTimeline(cachedData);
+    });
+  }
 }
 
 function handleTimelineClick(e) {
@@ -48,7 +74,22 @@ function renderTimeline(data) {
     return;
   }
 
-  const { rounds, agents, summary } = data;
+  const limit = getLimit();
+  const allRounds = data.rounds;
+  const rounds = limit === 'All' ? allRounds : allRounds.slice(-limit);
+  const agents = [...new Set(rounds.map(r => r.agent))];
+
+  // Recompute summary for visible rounds
+  const summary = {
+    total: rounds.length,
+    success: rounds.filter(r => r.outcome === 'success').length,
+    error: rounds.filter(r => r.outcome !== 'success').length,
+    avgDuration: rounds.length > 0
+      ? rounds.reduce((s, r) => s + r.duration, 0) / rounds.length
+      : 0,
+    maxDuration: rounds.reduce((m, r) => Math.max(m, r.duration), 0) || 1,
+  };
+
   const maxDur = summary.maxDuration || 1;
 
   // Group rounds by agent for swim lanes

--- a/src/index.html
+++ b/src/index.html
@@ -86,7 +86,19 @@
     </section>
 
     <!-- Round Timeline -->
-    <div class="section-title">Round Timeline</div>
+    <div class="section-title">
+      Round Timeline
+      <span class="timeline-filter">
+        <label for="timeline-limit">Show last</label>
+        <select id="timeline-limit">
+          <option value="10">10</option>
+          <option value="20">20</option>
+          <option value="30">30</option>
+          <option value="50">50</option>
+          <option value="All">All</option>
+        </select>
+      </span>
+    </div>
     <div class="card" id="timeline">
       <p class="empty-state">No round data yet.</p>
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -302,6 +302,36 @@ body {
   border-radius: 1px;
 }
 
+/* Timeline filter dropdown */
+.timeline-filter {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 400;
+}
+.timeline-filter label {
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  font-family: var(--mono);
+}
+.timeline-filter select {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.15rem 0.35rem;
+  outline: none;
+  cursor: pointer;
+}
+.timeline-filter select:focus {
+  border-color: var(--blue);
+}
+
 /* ── Cards ─────────────────────────────────────────────── */
 .card {
   background: var(--surface);


### PR DESCRIPTION
## Changes

- **Default**: timeline now shows last **10 rounds** instead of all rounds
- **Dropdown**: added a 'Show last' selector with options: 10, 20, 30, 50, All
- **Persistence**: selection saved in \localStorage\ (\fs-timeline-limit\ key)
- **Summary**: stats recompute for visible rounds only (not all-time)

### Files changed
- \src/components/timeline.js\ — filtering logic, localStorage read/write, re-render on change
- \src/index.html\ — dropdown in section header
- \src/styles.css\ — \.timeline-filter\ styles matching existing dashboard components

Closes #14