### PR TITLE
fix: Sync squad-triage.yml with Hub content-aware triage verdicts [#19]

### DIFF
--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -199,12 +199,24 @@ jobs:
               labels: [assignLabel]
             });
 
-            // Apply default triage verdict
+            // Apply triage verdict based on issue quality
+            // If the issue has acceptance criteria or clear structure, mark as ready
+            // Otherwise, mark as needs-research
+            const body = issue.body || '';
+            const bodyLength = body.trim().length;
+            const hasAcceptanceCriteria = /acceptance\s+criteria/i.test(body);
+            const hasChecklist = /- \[ \]/.test(body);
+            const hasStructuredSections = /^##\s+.+/m.test(body);
+            const hasRequirements = /requirements/i.test(body);
+
+            const isWellDefined = bodyLength >= 100 && (hasAcceptanceCriteria || hasChecklist || hasStructuredSections || hasRequirements);
+            const triageLabel = isWellDefined ? 'go:ready' : 'go:needs-research';
+
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
-              labels: ['go:needs-research']
+              labels: [triageLabel]
             });
 
             // Auto-assign @copilot if enabled


### PR DESCRIPTION
## Summary

Syncs the squad-triage.yml workflow with the Hub fix from PR #191.

## Problem
The old workflow unconditionally applied go:needs-research to every triaged issue, regardless of issue quality.

## Fix
Replace with content-aware heuristic: well-defined issues (100+ chars body with acceptance criteria, checklists, or structured sections) get go:ready. Others get go:needs-research.

Closes #19