### PR TITLE
test: add config and mockData service tests to fix coverage threshold

### DIFF
--- a/src/services/__tests__/config.test.js
+++ b/src/services/__tests__/config.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { fetchConfig, getConfigSync, clearConfigCache } from '../config.js'
+
+describe('config service', () => {
+  let mockFetch
+
+  beforeEach(() => {
+    clearConfigCache()
+    mockFetch = vi.fn()
+    global.fetch = mockFetch
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('fetchConfig', () => {
+    it('should fetch and return config from /api/config', async () => {
+      const mockData = { REPOS: ['repo1'], AGENTS: ['agent1'] }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => mockData,
+      })
+
+      const result = await fetchConfig()
+
+      expect(mockFetch).toHaveBeenCalledWith('/api/config')
+      expect(result).toEqual(mockData)
+    })
+
+    it('should return cached config on subsequent calls', async () => {
+      const mockData = { REPOS: ['repo1'], AGENTS: ['agent1'] }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => mockData,
+      })
+
+      const first = await fetchConfig()
+      const second = await fetchConfig()
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(second).toBe(first)
+    })
+
+    it('should deduplicate concurrent requests', async () => {
+      const mockData = { REPOS: ['repo1'] }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => mockData,
+      })
+
+      const [r1, r2] = await Promise.all([fetchConfig(), fetchConfig()])
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(r1).toEqual(mockData)
+      expect(r2).toEqual(mockData)
+    })
+
+    it('should throw on non-ok HTTP response', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500 })
+
+      await expect(fetchConfig()).rejects.toThrow('Config fetch failed: HTTP 500')
+    })
+
+    it('should throw on network error', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'))
+
+      await expect(fetchConfig()).rejects.toThrow('Network error')
+    })
+
+    it('should clear configPromise on error so retries work', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Temporary failure'))
+
+      await expect(fetchConfig()).rejects.toThrow('Temporary failure')
+
+      const mockData = { REPOS: ['repo1'] }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => mockData,
+      })
+
+      const result = await fetchConfig()
+      expect(result).toEqual(mockData)
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('getConfigSync', () => {
+    it('should return null before config is fetched', () => {
+      expect(getConfigSync()).toBeNull()
+    })
+
+    it('should return cached config after fetch', async () => {
+      const mockData = { REPOS: ['repo1'] }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => mockData,
+      })
+
+      await fetchConfig()
+
+      expect(getConfigSync()).toEqual(mockData)
+    })
+  })
+
+  describe('clearConfigCache', () => {
+    it('should clear the cached config', async () => {
+      const mockData = { REPOS: ['repo1'] }
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => mockData,
+      })
+
+      await fetchConfig()
+      expect(getConfigSync()).toEqual(mockData)
+
+      clearConfigCache()
+      expect(getConfigSync()).toBeNull()
+    })
+
+    it('should force re-fetch after clearing', async () => {
+      const firstData = { REPOS: ['repo1'] }
+      const secondData = { REPOS: ['repo2'] }
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => firstData })
+        .mockResolvedValueOnce({ ok: true, json: async () => secondData })
+
+      await fetchConfig()
+      clearConfigCache()
+      const result = await fetchConfig()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(result).toEqual(secondData)
+    })
+  })
+})

--- a/src/services/__tests__/mockData.test.js
+++ b/src/services/__tests__/mockData.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { getAgentWorkload, getCostHistory, getCIMinutesUsage } from '../mockData.js'
+
+describe('mockData service', () => {
+  describe('getAgentWorkload', () => {
+    it('should return an empty array', () => {
+      expect(getAgentWorkload()).toEqual([])
+    })
+  })
+
+  describe('getCostHistory', () => {
+    it('should return 30 days of cost data', () => {
+      const result = getCostHistory()
+      expect(result).toHaveLength(30)
+    })
+
+    it('should include date, actual, and budget fields', () => {
+      const result = getCostHistory()
+      for (const day of result) {
+        expect(day).toHaveProperty('date')
+        expect(day).toHaveProperty('actual', 0)
+        expect(day).toHaveProperty('budget')
+        expect(typeof day.budget).toBe('number')
+      }
+    })
+
+    it('should have dates in YYYY-MM-DD format', () => {
+      const result = getCostHistory()
+      for (const day of result) {
+        expect(day.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      }
+    })
+  })
+
+  describe('getCIMinutesUsage', () => {
+    it('should return usage object with used, total, and percentage', () => {
+      const result = getCIMinutesUsage()
+      expect(result).toEqual({
+        used: 420,
+        total: 2000,
+        percentage: 21,
+      })
+    })
+  })
+})


### PR DESCRIPTION
Closes coverage threshold failure — functions coverage was at 77.35%, below the 80% required.

## Changes

- **\src/services/__tests__/config.test.js\** — 10 tests covering \etchConfig()\, \getConfigSync()\, \clearConfigCache()\, caching, request deduplication, and error handling.
- **\src/services/__tests__/mockData.test.js\** — 5 tests covering all three exported functions.

## Coverage Results

| Metric | Before | After |
|--------|--------|-------|
| Statements | ~88% | 96.63% |
| Branches | ~87% | 95.65% |
| Functions | 77.35% | 94.33% |
| Lines | ~90% | 97.84% |

All 105 tests pass. All thresholds now exceed 80%.