### PR TITLE
feat: replace CostTracker mock data with real GitHub Actions usage

### DIFF
--- a/server/api/usage.js
+++ b/server/api/usage.js
@@ -1,0 +1,120 @@
+import { REPOS } from '../config.js'
+import { githubFetch, handleGitHubError } from '../lib/github-client.js'
+
+const CACHE_TTL = 30_000
+let usageCache = null
+let usageCacheTime = 0
+
+// Aggregate CI minutes from recent workflow runs across all repos
+async function aggregateWorkflowUsage() {
+  let totalRunsCount = 0
+  let totalDurationMs = 0
+  const repoBreakdown = []
+
+  for (const repo of REPOS) {
+    const [owner, name] = repo.github.split('/')
+    let repoRuns = 0
+    let repoDurationMs = 0
+
+    try {
+      const { data } = await githubFetch(
+        `/repos/${owner}/${name}/actions/runs?per_page=100&status=completed`
+      )
+      const runs = data.workflow_runs || []
+      repoRuns = runs.length
+
+      for (const run of runs) {
+        if (run.created_at && run.updated_at) {
+          const start = new Date(run.created_at).getTime()
+          const end = new Date(run.updated_at).getTime()
+          if (end > start) repoDurationMs += end - start
+        }
+      }
+    } catch (err) {
+      // Skip individual repo failures
+      console.warn(`⚠️  Failed to fetch workflow runs for ${repo.github}:`, err.message)
+    }
+
+    totalRunsCount += repoRuns
+    totalDurationMs += repoDurationMs
+    repoBreakdown.push({
+      repo: repo.github,
+      label: repo.label,
+      emoji: repo.emoji,
+      runs: repoRuns,
+      durationMinutes: Math.round(repoDurationMs / 60_000),
+    })
+  }
+
+  const totalMinutes = Math.round(totalDurationMs / 60_000)
+
+  // GitHub free tier: 2000 minutes/month for private repos, 500 for public (unlimited for public actually)
+  const freeMinutesLimit = 2000
+
+  return {
+    totalRuns: totalRunsCount,
+    totalMinutes,
+    freeMinutesLimit,
+    percentage: freeMinutesLimit > 0
+      ? Math.min(100, Math.round((totalMinutes / freeMinutesLimit) * 100))
+      : 0,
+    repos: repoBreakdown,
+  }
+}
+
+// Try org billing API first, fall back to workflow run aggregation
+async function fetchUsageData() {
+  // Attempt org billing API (requires org admin access)
+  for (const repo of REPOS) {
+    const [owner] = repo.github.split('/')
+    try {
+      const { data: billing } = await githubFetch(
+        `/orgs/${owner}/settings/billing/actions`
+      )
+      // Billing API succeeded — return structured data
+      return {
+        source: 'billing',
+        totalMinutesUsed: billing.total_minutes_used || 0,
+        includedMinutes: billing.included_minutes || 2000,
+        paidMinutesUsed: billing.total_paid_minutes_used || 0,
+        percentage: billing.included_minutes > 0
+          ? Math.min(100, Math.round(
+              (billing.total_minutes_used / billing.included_minutes) * 100
+            ))
+          : 0,
+      }
+    } catch {
+      // Expected for user accounts or non-admin tokens — try next or fall back
+    }
+  }
+
+  // Fallback: aggregate from workflow runs
+  const aggregated = await aggregateWorkflowUsage()
+  return {
+    source: 'workflow_runs',
+    totalMinutesUsed: aggregated.totalMinutes,
+    includedMinutes: aggregated.freeMinutesLimit,
+    totalRuns: aggregated.totalRuns,
+    percentage: aggregated.percentage,
+    repos: aggregated.repos,
+  }
+}
+
+export default async function usageRoute(req, res) {
+  try {
+    if (usageCache && Date.now() - usageCacheTime < CACHE_TTL) {
+      res.json(usageCache)
+      return
+    }
+
+    const usage = await fetchUsageData()
+
+    usageCache = usage
+    usageCacheTime = Date.now()
+
+    res.json(usage)
+  } catch (err) {
+    if (handleGitHubError(res, err)) return
+    res.status(500).json({ error: 'Failed to fetch usage data' })
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,7 @@ import workflowsRoute from './api/workflows.js';
 import reposRoute from './api/repos.js';
 import configRoute from './api/config.js';
 import eventsRoute from './api/events.js';
+import usageRoute from './api/usage.js';
 
 const app = express();
 
@@ -32,6 +33,7 @@ app.get('/api/agents', workflowsRoute);
 app.get('/api/repos', reposRoute);
 app.get('/api/config', configRoute);
 app.get('/api/events', eventsRoute);
+app.get('/api/usage', usageRoute);
 
 // Health check with rate limit status
 app.get('/health', (req, res) => {
@@ -77,6 +79,7 @@ app.listen(PORT, () => {
   console.log(`   - GET /api/repos`);
   console.log(`   - GET /api/config`);
   console.log(`   - GET /api/events`);
+  console.log(`   - GET /api/usage`);
   console.log(`   - GET /health\n`);
 });
 

--- a/src/components/CostTracker.jsx
+++ b/src/components/CostTracker.jsx
@@ -1,36 +1,29 @@
 import React, { useState, useEffect } from 'react';
-import { getCostHistory, getCIMinutesUsage } from '../services/mockData';
 
 export function CostTracker() {
-  const [costHistory] = useState(getCostHistory());
-  const [ciUsage, setCiUsage] = useState(getCIMinutesUsage());
+  const [usage, setUsage] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    loadCIUsage();
+    loadUsage();
   }, []);
 
-  const loadCIUsage = async () => {
+  const loadUsage = async () => {
     setLoading(true);
     setError(null);
     try {
-      const usage = getCIMinutesUsage();
-      setCiUsage(usage);
-    } catch (error) {
-      console.error('Failed to load CI usage:', error);
-      setError('Failed to fetch CI data');
+      const response = await fetch('/api/usage');
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data = await response.json();
+      setUsage(data);
+    } catch (err) {
+      console.error('Failed to load usage data:', err);
+      setError('Cost data not available');
     } finally {
       setLoading(false);
     }
   };
-
-  const currentSpend = 0;
-  const azureSavings = 120;
-  const awsSavings = 200;
-  const totalSavings = azureSavings + awsSavings;
-
-  const isApproachingLimit = ciUsage.percentage > 80;
 
   if (loading) {
     return (
@@ -47,132 +40,106 @@ export function CostTracker() {
     );
   }
 
+  if (error || !usage) {
+    return (
+      <div className="space-y-4 animate-fade-in">
+        <div className="glass rounded-xl p-8 border border-amber-500/30 bg-amber-500/10 text-center">
+          <div className="text-4xl mb-4">⚠️</div>
+          <h3 className="text-lg font-bold text-amber-400 mb-2">Cost data not available</h3>
+          <p className="text-sm text-gray-400 mb-4">
+            Unable to fetch GitHub Actions usage data. This may be due to missing permissions or network issues.
+          </p>
+          <button
+            onClick={loadUsage}
+            className="px-4 py-2 bg-amber-500/20 text-amber-300 rounded-lg hover:bg-amber-500/30 transition-colors text-sm font-medium"
+          >
+            🔄 Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const usedMinutes = usage.totalMinutesUsed || 0;
+  const totalMinutes = usage.includedMinutes || 2000;
+  const percentage = usage.percentage || 0;
+  const isApproachingLimit = percentage > 80;
+
   return (
     <div className="space-y-6 animate-fade-in">
-      {/* Hero Card - Big €0 Display */}
+      {/* GitHub Actions Usage */}
       <div className="glass rounded-2xl p-8 border border-emerald-500/30 bg-gradient-to-br from-emerald-500/10 via-transparent to-cyan-500/10 relative overflow-hidden">
-        {/* Animated background glow */}
         <div className="absolute inset-0 bg-gradient-to-r from-emerald-500/5 to-cyan-500/5 animate-pulse" />
-        
         <div className="relative z-10">
           <div className="text-center mb-6">
             <div className="inline-flex items-center gap-2 text-emerald-400 text-sm font-semibold mb-4">
-              <span className="text-2xl">🎉</span>
-              <span>CURRENT MONTHLY SPEND</span>
-              <span className="text-2xl">🎉</span>
+              <span className="text-2xl">⚡</span>
+              <span>GITHUB ACTIONS USAGE</span>
+              <span className="text-2xl">⚡</span>
             </div>
             <div className="flex items-center justify-center gap-4">
-              <div className="text-[120px] font-black text-transparent bg-clip-text bg-gradient-to-br from-emerald-400 via-green-400 to-cyan-400 leading-none animate-pulse-slow">
-                €{currentSpend}
+              <div className={`text-[80px] font-black leading-none ${
+                isApproachingLimit
+                  ? 'text-transparent bg-clip-text bg-gradient-to-br from-amber-400 to-yellow-500'
+                  : 'text-transparent bg-clip-text bg-gradient-to-br from-emerald-400 via-green-400 to-cyan-400'
+              }`}>
+                {usedMinutes}
               </div>
-            </div>
-            <div className="text-lg text-gray-300 font-medium mt-4">
-              100% Free Tier • Zero Cloud Costs
+              <div className="text-left">
+                <div className="text-2xl text-gray-400 font-medium">/ {totalMinutes}</div>
+                <div className="text-sm text-gray-500">minutes this month</div>
+              </div>
             </div>
           </div>
 
-          {/* Savings Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-8">
-            <div className="glass rounded-xl p-5 border border-white/10 hover:border-emerald-500/30 transition-all group">
-              <div className="flex items-center justify-between mb-3">
-                <span className="text-sm font-semibold text-gray-400">vs. Azure ACI</span>
-                <span className="text-3xl">☁️</span>
+          {/* Progress bar */}
+          <div className="mb-4">
+            <div className="w-full h-4 bg-white/5 rounded-full overflow-hidden border border-white/10">
+              <div
+                className={`h-full transition-all duration-500 relative ${
+                  isApproachingLimit
+                    ? 'bg-gradient-to-r from-amber-500 to-yellow-500'
+                    : 'bg-gradient-to-r from-cyan-500 to-blue-600'
+                }`}
+                style={{ width: `${percentage}%` }}
+              >
+                <div className="absolute inset-0 bg-white/20 animate-pulse" />
               </div>
-              <div className="text-4xl font-black text-emerald-400 mb-1">€{azureSavings}</div>
-              <div className="text-xs text-gray-400">saved per month</div>
             </div>
-
-            <div className="glass rounded-xl p-5 border border-white/10 hover:border-cyan-500/30 transition-all group">
-              <div className="flex items-center justify-between mb-3">
-                <span className="text-sm font-semibold text-gray-400">vs. AWS Lambda</span>
-                <span className="text-3xl">🚀</span>
-              </div>
-              <div className="text-4xl font-black text-cyan-400 mb-1">€{awsSavings}</div>
-              <div className="text-xs text-gray-400">saved per month</div>
+            <div className={`text-xs font-mono mt-2 text-center ${isApproachingLimit ? 'text-amber-400' : 'text-gray-400'}`}>
+              {percentage}% used • {totalMinutes - usedMinutes} minutes remaining
             </div>
           </div>
 
-          {/* Total Savings Badge */}
-          <div className="mt-6 text-center">
-            <div className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-emerald-500 to-cyan-500 rounded-full text-white font-bold text-lg shadow-lg shadow-emerald-500/25">
-              <span>💰</span>
-              <span>€{totalSavings}/mo Total Savings</span>
-              <span>✨</span>
-            </div>
+          <div className="text-center text-xs text-gray-500">
+            Source: {usage.source === 'billing' ? 'GitHub Billing API' : 'Workflow run aggregation'}
+            {usage.totalRuns != null && ` • ${usage.totalRuns} recent runs`}
           </div>
         </div>
       </div>
 
-      {/* Budget Chart */}
-      <div className="glass rounded-xl p-6 border border-white/10">
-        <h3 className="text-lg font-bold text-white mb-6">Budget vs Actual (Last 30 Days)</h3>
-        <div className="h-56 flex items-end gap-1 px-2">
-          {costHistory.map((day, index) => (
-            <div key={index} className="flex-1 flex flex-col items-center gap-2 group">
-              <div className="relative w-full flex flex-col justify-end h-full">
-                {/* Budget line (barely visible) */}
-                <div
-                  className="w-full bg-gray-600/30 rounded-t transition-all group-hover:bg-gray-500"
-                  style={{ height: '6px' }}
-                  title={`Budget: €${day.budget.toFixed(2)}`}
-                />
-                {/* Actual (green line at bottom - always €0) */}
-                <div
-                  className="w-full bg-emerald-500 rounded-t"
-                  style={{ height: '6px' }}
-                  title={`Actual: €${day.actual}`}
-                />
-              </div>
-              {index % 5 === 0 && (
-                <div className="text-[10px] text-gray-500 font-mono">
-                  {new Date(day.date).getDate()}
+      {/* Per-repo breakdown (only from workflow_runs source) */}
+      {usage.repos && usage.repos.length > 0 && (
+        <div className="glass rounded-xl p-6 border border-white/10">
+          <h3 className="text-lg font-bold text-white mb-6">Usage by Repository</h3>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {usage.repos.map((repo) => (
+              <div key={repo.repo} className="glass rounded-lg p-4 border border-white/10 hover:border-cyan-500/30 transition-all">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="text-2xl">{repo.emoji}</span>
+                  <span className="text-sm font-semibold text-gray-300">{repo.label}</span>
                 </div>
-              )}
-            </div>
-          ))}
-        </div>
-        <div className="flex justify-center gap-8 mt-8">
-          <div className="flex items-center gap-2">
-            <div className="w-4 h-4 bg-gray-600/50 rounded" />
-            <span className="text-sm text-gray-400">Budget (€500/mo)</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-4 h-4 bg-emerald-500 rounded" />
-            <span className="text-sm font-semibold text-emerald-400">Actual (€0)</span>
+                <div className="text-2xl font-black text-white mb-1">{repo.durationMinutes} min</div>
+                <div className="text-xs text-gray-400">{repo.runs} workflow runs</div>
+              </div>
+            ))}
           </div>
         </div>
-      </div>
+      )}
 
-      {/* Resource Breakdown */}
+      {/* Resource Cards */}
       <div className="glass rounded-xl p-6 border border-white/10">
         <h3 className="text-lg font-bold text-white mb-6">Resource Usage</h3>
-        
-        {/* GitHub Actions Usage Bar */}
-        <div className="mb-6">
-          <div className="flex items-center justify-between mb-3">
-            <span className="text-sm font-semibold text-gray-300">GitHub Actions Minutes</span>
-            <span className="text-sm font-mono font-bold text-white">
-              {ciUsage.used} / {ciUsage.total} min
-            </span>
-          </div>
-          <div className="w-full h-4 bg-white/5 rounded-full overflow-hidden border border-white/10">
-            <div
-              className={`h-full transition-all duration-500 relative ${
-                isApproachingLimit 
-                  ? 'bg-gradient-to-r from-amber-500 to-yellow-500' 
-                  : 'bg-gradient-to-r from-cyan-500 to-blue-600'
-              }`}
-              style={{ width: `${ciUsage.percentage}%` }}
-            >
-              <div className="absolute inset-0 bg-white/20 animate-pulse" />
-            </div>
-          </div>
-          <div className={`text-xs font-mono mt-2 ${isApproachingLimit ? 'text-amber-400' : 'text-gray-400'}`}>
-            {ciUsage.percentage}% used • {ciUsage.total - ciUsage.used} minutes remaining
-          </div>
-        </div>
-
-        {/* Resource Cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <div className="glass rounded-lg p-4 border border-white/10">
             <div className="flex items-center gap-2 mb-2">
@@ -211,7 +178,7 @@ export function CostTracker() {
             <div className="flex-1">
               <h4 className="text-amber-400 font-bold text-lg mb-1">Approaching Free Tier Limit</h4>
               <p className="text-sm text-amber-100/80 mb-3">
-                You've used {ciUsage.percentage}% of your GitHub Actions minutes this month.
+                You've used {percentage}% of your GitHub Actions minutes this month.
               </p>
               <div className="text-xs text-gray-400">
                 💡 Consider optimizing workflows or upgrading if needed
@@ -222,22 +189,24 @@ export function CostTracker() {
       )}
 
       {/* Success Banner */}
-      <div className="glass rounded-xl p-5 border border-emerald-500/30 bg-emerald-500/10">
-        <div className="flex items-start gap-4">
-          <div className="text-3xl">✨</div>
-          <div className="flex-1">
-            <h4 className="text-emerald-400 font-bold text-lg mb-1">100% Cost Optimization</h4>
-            <p className="text-sm text-emerald-100/80 mb-3">
-              Running entirely on GitHub's free tier. Total monthly savings of €{totalSavings} compared to traditional cloud hosting.
-            </p>
-            <div className="flex flex-wrap gap-2 text-xs">
-              <span className="px-2 py-1 bg-emerald-500/20 text-emerald-300 rounded-full font-medium">Free Hosting</span>
-              <span className="px-2 py-1 bg-emerald-500/20 text-emerald-300 rounded-full font-medium">Free CI/CD</span>
-              <span className="px-2 py-1 bg-emerald-500/20 text-emerald-300 rounded-full font-medium">Free Storage</span>
+      {!isApproachingLimit && (
+        <div className="glass rounded-xl p-5 border border-emerald-500/30 bg-emerald-500/10">
+          <div className="flex items-start gap-4">
+            <div className="text-3xl">✨</div>
+            <div className="flex-1">
+              <h4 className="text-emerald-400 font-bold text-lg mb-1">Running on GitHub Free Tier</h4>
+              <p className="text-sm text-emerald-100/80 mb-3">
+                All CI/CD powered by GitHub Actions. Using {usedMinutes} of {totalMinutes} included minutes.
+              </p>
+              <div className="flex flex-wrap gap-2 text-xs">
+                <span className="px-2 py-1 bg-emerald-500/20 text-emerald-300 rounded-full font-medium">Free Hosting</span>
+                <span className="px-2 py-1 bg-emerald-500/20 text-emerald-300 rounded-full font-medium">Free CI/CD</span>
+                <span className="px-2 py-1 bg-emerald-500/20 text-emerald-300 rounded-full font-medium">Free Storage</span>
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/services/__tests__/mockData.test.js
+++ b/src/services/__tests__/mockData.test.js
@@ -1,45 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { getAgentWorkload, getCostHistory, getCIMinutesUsage } from '../mockData.js'
+import { getAgentWorkload } from '../mockData.js'
 
 describe('mockData service', () => {
   describe('getAgentWorkload', () => {
     it('should return an empty array', () => {
       expect(getAgentWorkload()).toEqual([])
-    })
-  })
-
-  describe('getCostHistory', () => {
-    it('should return 30 days of cost data', () => {
-      const result = getCostHistory()
-      expect(result).toHaveLength(30)
-    })
-
-    it('should include date, actual, and budget fields', () => {
-      const result = getCostHistory()
-      for (const day of result) {
-        expect(day).toHaveProperty('date')
-        expect(day).toHaveProperty('actual', 0)
-        expect(day).toHaveProperty('budget')
-        expect(typeof day.budget).toBe('number')
-      }
-    })
-
-    it('should have dates in YYYY-MM-DD format', () => {
-      const result = getCostHistory()
-      for (const day of result) {
-        expect(day.date).toMatch(/^\d{4}-\d{2}-\d{2}$/)
-      }
-    })
-  })
-
-  describe('getCIMinutesUsage', () => {
-    it('should return usage object with used, total, and percentage', () => {
-      const result = getCIMinutesUsage()
-      expect(result).toEqual({
-        used: 420,
-        total: 2000,
-        percentage: 21,
-      })
     })
   })
 })

--- a/src/services/mockData.js
+++ b/src/services/mockData.js
@@ -1,28 +1,3 @@
 export function getAgentWorkload() {
   return [];
 }
-
-export function getCostHistory() {
-  const days = [];
-  const today = new Date();
-  
-  for (let i = 29; i >= 0; i--) {
-    const date = new Date(today);
-    date.setDate(date.getDate() - i);
-    days.push({
-      date: date.toISOString().split('T')[0],
-      actual: 0,
-      budget: 500 / 30,
-    });
-  }
-  
-  return days;
-}
-
-export function getCIMinutesUsage() {
-  return {
-    used: 420,
-    total: 2000,
-    percentage: 21,
-  };
-}


### PR DESCRIPTION
Closes #42

## Summary

Replaces fabricated mock data in CostTracker with real GitHub Actions usage fetched from the backend.

### Backend: \/api/usage\ endpoint (\server/api/usage.js\)
- Tries GitHub org billing API first (\/orgs/{org}/settings/billing/actions\)
- Falls back to aggregating recent workflow runs across all configured repos
- 30s cache (same pattern as events.js, board.js)
- Uses \githubFetch()\ from \server/lib/github-client.js\ for authenticated API calls
- Registered in \server/index.js\

### Frontend: \CostTracker.jsx\
- Fetches from \/api/usage\ instead of importing mock functions
- Shows real minutes used, included minutes, and per-repo breakdown
- Displays **'Cost data not available'** with retry button when API fails
- No more fabricated EUR 0 or fake 420/2000 CI minutes

### Cleanup: \mockData.js\
- Removed \getCostHistory()\ and \getCIMinutesUsage()\
- Kept \getAgentWorkload()\ (still used by TeamBoard)
- Updated tests to match