### PR TITLE
fix: replace hardcoded data sources with Express backend endpoints

### DIFF
--- a/src/components/TeamBoard.jsx
+++ b/src/components/TeamBoard.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { fetchConfig } from '../services/config';
-import { getAgentWorkload } from '../services/mockData';
 
 export function TeamBoard() {
   const [agents, setAgents] = useState([]);
@@ -77,7 +76,7 @@ export function TeamBoard() {
     } catch (error) {
       console.error('Failed to load team data:', error);
       setError('Failed to fetch team data');
-      setWorkload(getAgentWorkload());
+      setWorkload([]);
     } finally {
       setLoading(false);
     }

--- a/src/components/__tests__/TeamBoard.test.jsx
+++ b/src/components/__tests__/TeamBoard.test.jsx
@@ -7,14 +7,7 @@ vi.mock('../../services/config', () => ({
   fetchConfig: vi.fn(),
 }))
 
-vi.mock('../../services/mockData', () => ({
-  getAgentWorkload: vi.fn(() => [
-    { agent: 'ripley', count: 0, label: 'Ripley' },
-  ]),
-}))
-
 import { fetchConfig } from '../../services/config'
-import { getAgentWorkload } from '../../services/mockData'
 
 const mockConfig = {
   agents: {
@@ -159,7 +152,7 @@ describe('TeamBoard', () => {
     })
   })
 
-  it('shows error state and falls back to mock workload data', async () => {
+  it('shows error state on fetch failure', async () => {
     global.fetch = vi.fn(() => Promise.reject(new Error('Network error')))
 
     render(<TeamBoard />)
@@ -167,7 +160,6 @@ describe('TeamBoard', () => {
       expect(screen.getByText(/Failed to fetch team data/)).toBeInTheDocument()
     })
     expect(screen.getByText('Showing cached data')).toBeInTheDocument()
-    expect(getAgentWorkload).toHaveBeenCalled()
   })
 
   it('shows error on HTTP error response', async () => {

--- a/src/hooks/usePolling.js
+++ b/src/hooks/usePolling.js
@@ -2,19 +2,13 @@ import { useEffect } from 'react';
 import { useStore } from '../store/store';
 
 const POLL_INTERVAL = 60000;
-const HEARTBEAT_URL = 'https://raw.githubusercontent.com/jperezdelreal/Syntax-Sorcery/main/.squad/heartbeat/ralph.json';
 
 export function usePolling() {
   const { setHeartbeatData, setError, lastUpdate, isConnected } = useStore();
 
   const fetchHeartbeat = async () => {
     try {
-      const response = await fetch(HEARTBEAT_URL, {
-        cache: 'no-cache',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
-      });
+      const response = await fetch('/api/heartbeat');
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);

--- a/src/services/mockData.js
+++ b/src/services/mockData.js
@@ -1,3 +1,7 @@
+/**
+ * @deprecated Demo-only fallback data. Real agent data comes from /api/config.
+ * This module is retained for test compatibility but is not used in production.
+ */
 export function getAgentWorkload() {
   return [];
 }


### PR DESCRIPTION
## Summary

Two related data source fixes to route all frontend data through the Express backend:

### Issue #41: Replace mock agent data with real backend data
- Removed getAgentWorkload import from TeamBoard.jsx (component already fetches agents from /api/config)
- Marked mockData.js as deprecated demo-only fallback
- Updated TeamBoard tests to remove mockData mock dependency

### Issue #43: Route heartbeat polling through Express backend
- Replaced hardcoded raw GitHub URL (Syntax-Sorcery repo) in usePolling.js
- Now fetches from /api/heartbeat which reads from the local heartbeat file with fs.watch caching
- Removed unnecessary cache-busting headers (backend handles freshness)

### Files changed
- src/components/TeamBoard.jsx - removed mockData import
- src/hooks/usePolling.js - switched to /api/heartbeat
- src/services/mockData.js - added deprecation comment
- src/components/__tests__/TeamBoard.test.jsx - removed mockData mock

### Verification
- npm run build passes (45 modules, 1.62s)
- All 12 TeamBoard + mockData tests pass
- Pre-existing CostTracker test failures unrelated to this change

Closes #41, Closes #43
