### PR TITLE
feat: historical metrics persistence layer with SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 coverage/
+data/
 .env
 *.log
 bundle-report.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tailwindcss/postcss": "^4.2.1",
         "@vitejs/plugin-react": "^5.2.0",
         "autoprefixer": "^10.4.27",
+        "better-sqlite3": "^12.6.2",
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "react": "^18.3.1",
@@ -1870,6 +1871,26 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.7",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
@@ -1880,6 +1901,40 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
+      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -1937,6 +1992,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bundle-name": {
@@ -2022,6 +2101,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/cliui": {
       "version": "9.0.1",
@@ -2123,6 +2208,30 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/default-browser": {
@@ -2244,6 +2353,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -2384,6 +2502,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2454,6 +2581,12 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2505,6 +2638,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2597,6 +2736,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -2711,6 +2856,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2725,6 +2890,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -3264,6 +3435,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -3273,6 +3456,21 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3298,6 +3496,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -3305,6 +3509,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.88.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.88.0.tgz",
+      "integrity": "sha512-At6b4UqIEVudaqPsXjmUO1r/N5BUr4yhDGs5PkBE8/oG5+TfLPhFechiskFsnT6Ql0VfUXbalUUCbfXxtj7K+w==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-releases": {
@@ -3478,6 +3694,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -3505,6 +3748,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -3544,6 +3797,21 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
     "node_modules/react": {
@@ -3586,6 +3854,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/redent": {
@@ -3706,6 +3988,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3725,7 +4027,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3864,6 +4165,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -3905,6 +4251,15 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -3966,6 +4321,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3996,6 +4360,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tinybench": {
@@ -4048,6 +4440,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-is": {
@@ -4109,6 +4513,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@tailwindcss/postcss": "^4.2.1",
     "@vitejs/plugin-react": "^5.2.0",
     "autoprefixer": "^10.4.27",
+    "better-sqlite3": "^12.6.2",
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "react": "^18.3.1",

--- a/server/api/health.js
+++ b/server/api/health.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import { config } from '../config.js'
 import { getRateLimitStatus, githubFetch } from '../lib/github-client.js'
 import { getHeartbeatResponse } from './heartbeat.js'
+import { getDbStats } from '../lib/metrics-db.js'
 import { logger } from '../lib/logger.js'
 
 let lastGithubCheck = null
@@ -71,6 +72,9 @@ export default async function healthRoute(req, res) {
         lastTimestamp: heartbeat.timestamp || null,
         healthy: heartbeatHealthy,
       },
+      metricsDb: (() => {
+        try { return getDbStats() } catch { return null }
+      })(),
     },
   })
 }

--- a/server/api/metrics.js
+++ b/server/api/metrics.js
@@ -1,0 +1,96 @@
+import {
+  querySnapshots,
+  getDailySummary,
+  queryAgentSnapshots,
+  getDbStats,
+} from '../lib/metrics-db.js'
+import { logger } from '../lib/logger.js'
+
+const VALID_INTERVALS = ['5m', '15m', '1h', '6h', '1d']
+const VALID_CHANNELS = ['issues', 'agents', 'actions']
+
+export function metricsRoute(req, res) {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`)
+    const channel = url.searchParams.get('channel')
+    const from = url.searchParams.get('from')
+    const to = url.searchParams.get('to')
+    const interval = url.searchParams.get('interval') || '1h'
+
+    if (!channel || !VALID_CHANNELS.includes(channel)) {
+      res.status(400).json({
+        error: `Invalid channel. Must be one of: ${VALID_CHANNELS.join(', ')}`,
+      })
+      return
+    }
+
+    if (!VALID_INTERVALS.includes(interval)) {
+      res.status(400).json({
+        error: `Invalid interval. Must be one of: ${VALID_INTERVALS.join(', ')}`,
+      })
+      return
+    }
+
+    const data = querySnapshots(channel, from, to, interval)
+    res.json({
+      channel,
+      interval,
+      from: from || null,
+      to: to || null,
+      count: data.length,
+      data,
+    })
+  } catch (err) {
+    logger.error('Metrics query failed', { error: err.message })
+    res.status(500).json({ error: 'Failed to query metrics' })
+  }
+}
+
+export function metricsSummaryRoute(req, res) {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`)
+    const date = url.searchParams.get('date')
+
+    if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      res.status(400).json({
+        error: 'Invalid date. Must be in YYYY-MM-DD format.',
+      })
+      return
+    }
+
+    const summary = getDailySummary(date)
+    res.json(summary)
+  } catch (err) {
+    logger.error('Metrics summary query failed', { error: err.message })
+    res.status(500).json({ error: 'Failed to query daily summary' })
+  }
+}
+
+export function metricsAgentsRoute(req, res) {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`)
+    const from = url.searchParams.get('from')
+    const to = url.searchParams.get('to')
+
+    const data = queryAgentSnapshots(from, to)
+    res.json({
+      from: from || null,
+      to: to || null,
+      count: data.length,
+      data,
+    })
+  } catch (err) {
+    logger.error('Agent metrics query failed', { error: err.message })
+    res.status(500).json({ error: 'Failed to query agent metrics' })
+  }
+}
+
+export function metricsStatsRoute(req, res) {
+  try {
+    const stats = getDbStats()
+    res.json(stats)
+  } catch (err) {
+    logger.error('Metrics stats query failed', { error: err.message })
+    res.status(500).json({ error: 'Failed to query metrics stats' })
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,8 @@ import cors from 'cors';
 import { config } from './config.js';
 import { getRateLimitStatus } from './lib/github-client.js';
 import { logger, requestLogger } from './lib/logger.js';
+import { startSnapshotService, stopSnapshotService } from './lib/snapshot-service.js';
+import { closeDb, getDbStats } from './lib/metrics-db.js';
 
 // Import route handlers
 import heartbeatRoute from './api/heartbeat.js';
@@ -16,6 +18,7 @@ import configRoute from './api/config.js';
 import eventsRoute from './api/events.js';
 import usageRoute from './api/usage.js';
 import healthRoute from './api/health.js';
+import { metricsRoute, metricsSummaryRoute, metricsAgentsRoute, metricsStatsRoute } from './api/metrics.js';
 
 const app = express();
 
@@ -38,10 +41,18 @@ app.get('/api/config', configRoute);
 app.get('/api/events', eventsRoute);
 app.get('/api/usage', usageRoute);
 app.get('/api/health', healthRoute);
+app.get('/api/metrics', metricsRoute);
+app.get('/api/metrics/summary', metricsSummaryRoute);
+app.get('/api/metrics/agents', metricsAgentsRoute);
+app.get('/api/metrics/stats', metricsStatsRoute);
 
 // Health check with rate limit status
 app.get('/health', (req, res) => {
   const rl = getRateLimitStatus();
+  let dbStats = null;
+  try {
+    dbStats = getDbStats();
+  } catch { /* db may not be initialized */ }
   res.json({
     status: 'ok',
     timestamp: new Date().toISOString(),
@@ -54,6 +65,7 @@ app.get('/health', (req, res) => {
         lastChecked: rl.lastChecked,
       },
     },
+    metricsDb: dbStats,
   });
 });
 
@@ -79,18 +91,23 @@ app.listen(PORT, () => {
     endpoints: [
       '/api/heartbeat', '/api/logs/files', '/api/logs/stream', '/api/logs',
       '/api/timeline', '/api/issues', '/api/pulse', '/api/agents',
-      '/api/repos', '/api/config', '/api/events', '/api/usage', '/api/health', '/health',
+      '/api/repos', '/api/config', '/api/events', '/api/usage', '/api/health',
+      '/api/metrics', '/api/metrics/summary', '/api/metrics/agents', '/api/metrics/stats',
+      '/health',
     ],
   });
+
+  // Start metrics snapshot service
+  startSnapshotService();
 });
 
 // Graceful shutdown
-process.on('SIGTERM', () => {
-  logger.info('Shutdown signal received', { signal: 'SIGTERM' });
+function shutdown(signal) {
+  logger.info('Shutdown signal received', { signal });
+  stopSnapshotService();
+  closeDb();
   process.exit(0);
-});
+}
 
-process.on('SIGINT', () => {
-  logger.info('Shutdown signal received', { signal: 'SIGINT' });
-  process.exit(0);
-});
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/server/lib/metrics-db.js
+++ b/server/lib/metrics-db.js
@@ -1,0 +1,256 @@
+import Database from 'better-sqlite3'
+import path from 'path'
+import fs from 'fs'
+import { fileURLToPath } from 'url'
+import { logger } from './logger.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const DEFAULT_DB_PATH = path.resolve(__dirname, '..', '..', 'data', 'metrics.sqlite')
+
+const DB_PATH = process.env.METRICS_DB_PATH || DEFAULT_DB_PATH
+const RETENTION_DAYS = 30
+
+let db = null
+
+const SCHEMA_VERSION = 1
+
+const MIGRATIONS = [
+  `CREATE TABLE IF NOT EXISTS metrics_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    channel TEXT NOT NULL,
+    data TEXT NOT NULL,
+    hash TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_snapshots_channel_ts
+    ON metrics_snapshots (channel, timestamp)`,
+  `CREATE TABLE IF NOT EXISTS daily_summaries (
+    date TEXT NOT NULL,
+    channel TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (date, channel)
+  )`,
+  `CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER NOT NULL
+  )`,
+]
+
+export function getDb() {
+  if (db) return db
+  db = initDb()
+  return db
+}
+
+function initDb() {
+  const dir = path.dirname(DB_PATH)
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true })
+  }
+
+  const instance = new Database(DB_PATH)
+  instance.pragma('journal_mode = WAL')
+  instance.pragma('foreign_keys = ON')
+
+  migrate(instance)
+
+  logger.info('Metrics database initialized', { path: DB_PATH })
+  return instance
+}
+
+function migrate(instance) {
+  instance.transaction(() => {
+    for (const sql of MIGRATIONS) {
+      instance.exec(sql)
+    }
+    const row = instance.prepare('SELECT version FROM schema_version').get()
+    if (!row) {
+      instance.prepare('INSERT INTO schema_version (version) VALUES (?)').run(SCHEMA_VERSION)
+    }
+  })()
+}
+
+// --- Snapshot CRUD ---
+
+export function insertSnapshot(channel, timestamp, data, hash = null) {
+  const db = getDb()
+  const stmt = db.prepare(
+    'INSERT INTO metrics_snapshots (channel, timestamp, data, hash) VALUES (?, ?, ?, ?)'
+  )
+  return stmt.run(channel, timestamp, JSON.stringify(data), hash)
+}
+
+export function getLatestSnapshotHash(channel) {
+  const db = getDb()
+  const row = db.prepare(
+    'SELECT hash FROM metrics_snapshots WHERE channel = ? ORDER BY timestamp DESC LIMIT 1'
+  ).get(channel)
+  return row?.hash || null
+}
+
+export function querySnapshots(channel, from, to, interval = '5m') {
+  const db = getDb()
+
+  let query = 'SELECT id, timestamp, channel, data FROM metrics_snapshots WHERE channel = ?'
+  const params = [channel]
+
+  if (from) {
+    query += ' AND timestamp >= ?'
+    params.push(from)
+  }
+  if (to) {
+    query += ' AND timestamp <= ?'
+    params.push(to)
+  }
+
+  query += ' ORDER BY timestamp ASC'
+  const rows = db.prepare(query).all(...params)
+
+  const parsed = rows.map(r => ({
+    id: r.id,
+    timestamp: r.timestamp,
+    channel: r.channel,
+    data: JSON.parse(r.data),
+  }))
+
+  return aggregateByInterval(parsed, interval)
+}
+
+function aggregateByInterval(rows, interval) {
+  if (!rows.length || interval === '5m') return rows
+
+  const bucketMs = intervalToMs(interval)
+  if (!bucketMs) return rows
+
+  const buckets = new Map()
+  for (const row of rows) {
+    const ts = new Date(row.timestamp).getTime()
+    const bucketKey = Math.floor(ts / bucketMs) * bucketMs
+    if (!buckets.has(bucketKey)) {
+      buckets.set(bucketKey, [])
+    }
+    buckets.get(bucketKey).push(row)
+  }
+
+  // Take last snapshot per bucket (most recent state)
+  return Array.from(buckets.entries()).map(([bucketTs, items]) => {
+    const last = items[items.length - 1]
+    return {
+      timestamp: new Date(bucketTs).toISOString(),
+      channel: last.channel,
+      data: last.data,
+    }
+  })
+}
+
+function intervalToMs(interval) {
+  const match = interval.match(/^(\d+)(m|h|d)$/)
+  if (!match) return null
+  const [, num, unit] = match
+  const n = parseInt(num, 10)
+  switch (unit) {
+    case 'm': return n * 60 * 1000
+    case 'h': return n * 60 * 60 * 1000
+    case 'd': return n * 24 * 60 * 60 * 1000
+    default: return null
+  }
+}
+
+// --- Daily Summaries ---
+
+export function upsertDailySummary(date, channel, summary) {
+  const db = getDb()
+  const stmt = db.prepare(
+    `INSERT INTO daily_summaries (date, channel, summary)
+     VALUES (?, ?, ?)
+     ON CONFLICT(date, channel)
+     DO UPDATE SET summary = excluded.summary, created_at = datetime('now')`
+  )
+  return stmt.run(date, channel, JSON.stringify(summary))
+}
+
+export function getDailySummary(date) {
+  const db = getDb()
+  const rows = db.prepare(
+    'SELECT date, channel, summary FROM daily_summaries WHERE date = ?'
+  ).all(date)
+
+  const result = {}
+  for (const row of rows) {
+    result[row.channel] = JSON.parse(row.summary)
+  }
+  return { date, channels: result }
+}
+
+// --- Agent Metrics ---
+
+export function queryAgentSnapshots(from, to) {
+  const db = getDb()
+  let query = `SELECT timestamp, data FROM metrics_snapshots WHERE channel = 'agents'`
+  const params = []
+
+  if (from) {
+    query += ' AND timestamp >= ?'
+    params.push(from)
+  }
+  if (to) {
+    query += ' AND timestamp <= ?'
+    params.push(to)
+  }
+
+  query += ' ORDER BY timestamp ASC'
+  return db.prepare(query).all(...params).map(r => ({
+    timestamp: r.timestamp,
+    agents: JSON.parse(r.data),
+  }))
+}
+
+// --- Retention ---
+
+export function pruneOldSnapshots() {
+  const db = getDb()
+  const cutoff = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString()
+  const result = db.prepare(
+    'DELETE FROM metrics_snapshots WHERE timestamp < ?'
+  ).run(cutoff)
+
+  if (result.changes > 0) {
+    logger.info('Pruned old metrics snapshots', { deleted: result.changes, cutoff })
+  }
+  return result.changes
+}
+
+// --- Health ---
+
+export function getDbStats() {
+  const db = getDb()
+  const snapshotCount = db.prepare('SELECT COUNT(*) as count FROM metrics_snapshots').get().count
+  const summaryCount = db.prepare('SELECT COUNT(*) as count FROM daily_summaries').get().count
+
+  let sizeBytes = 0
+  try {
+    const stat = fs.statSync(DB_PATH)
+    sizeBytes = stat.size
+  } catch { /* file may not exist yet */ }
+
+  return {
+    path: DB_PATH,
+    sizeBytes,
+    sizeMB: Math.round(sizeBytes / 1024 / 1024 * 100) / 100,
+    snapshots: snapshotCount,
+    summaries: summaryCount,
+    retentionDays: RETENTION_DAYS,
+  }
+}
+
+// --- Lifecycle ---
+
+export function closeDb() {
+  if (db) {
+    db.close()
+    db = null
+    logger.info('Metrics database closed')
+  }
+}

--- a/server/lib/snapshot-service.js
+++ b/server/lib/snapshot-service.js
@@ -1,0 +1,233 @@
+import crypto from 'crypto'
+import { REPOS, SQUAD_AGENTS } from '../config.js'
+import { githubFetch } from './github-client.js'
+import {
+  insertSnapshot,
+  getLatestSnapshotHash,
+  upsertDailySummary,
+  pruneOldSnapshots,
+  querySnapshots,
+} from './metrics-db.js'
+import { logger } from './logger.js'
+
+const log = logger.child({ service: 'snapshot' })
+
+const INTERVALS = {
+  issues: 5 * 60 * 1000,
+  agents: 5 * 60 * 1000,
+  actions: 15 * 60 * 1000,
+}
+
+const timers = {}
+let lastDailySummaryDate = null
+
+function dataHash(data) {
+  return crypto.createHash('sha256').update(JSON.stringify(data)).digest('hex').slice(0, 16)
+}
+
+function skipIfUnchanged(channel, data) {
+  const hash = dataHash(data)
+  const lastHash = getLatestSnapshotHash(channel)
+  if (hash === lastHash) {
+    log.debug('Snapshot unchanged, skipping', { channel })
+    return true
+  }
+  return false
+}
+
+// --- Issue Snapshots ---
+
+async function snapshotIssues() {
+  try {
+    const counts = { total: 0, open: 0, closed: 0, repos: {} }
+
+    for (const repo of REPOS) {
+      const [owner, name] = repo.github.split('/')
+      try {
+        const { data: openIssues } = await githubFetch(
+          `/repos/${owner}/${name}/issues?state=open&per_page=1`
+        )
+        const { data: closedIssues } = await githubFetch(
+          `/repos/${owner}/${name}/issues?state=closed&per_page=1`
+        )
+
+        const repoOpen = openIssues.filter(i => !i.pull_request).length
+        const repoClosed = closedIssues.filter(i => !i.pull_request).length
+
+        counts.repos[repo.id] = { open: repoOpen, closed: repoClosed }
+        counts.open += repoOpen
+        counts.closed += repoClosed
+      } catch (err) {
+        log.warn('Failed to snapshot issues for repo', { repo: repo.id, error: err.message })
+      }
+    }
+    counts.total = counts.open + counts.closed
+
+    if (skipIfUnchanged('issues', counts)) return
+    const ts = new Date().toISOString()
+    insertSnapshot('issues', ts, counts, dataHash(counts))
+    log.info('Issues snapshot saved', { open: counts.open, closed: counts.closed })
+  } catch (err) {
+    log.error('Issues snapshot failed', { error: err.message })
+  }
+}
+
+// --- Agent Status Snapshots ---
+
+async function snapshotAgents() {
+  try {
+    const agentData = {}
+    for (const [id, meta] of Object.entries(SQUAD_AGENTS)) {
+      agentData[id] = {
+        role: meta.role,
+        repo: meta.repo,
+        status: 'idle',
+      }
+    }
+
+    // Try to get real agent statuses from the agents API
+    try {
+      const response = await fetch(`http://localhost:${process.env.PORT || 3001}/api/agents`, {
+        signal: AbortSignal.timeout(5000),
+      })
+      if (response.ok) {
+        const agents = await response.json()
+        for (const agent of agents) {
+          if (agentData[agent.id]) {
+            agentData[agent.id].status = agent.status || 'idle'
+            agentData[agent.id].currentWork = agent.currentWork || null
+            agentData[agent.id].lastActivity = agent.lastActivity || null
+          }
+        }
+      }
+    } catch {
+      // Server might not be fully ready
+    }
+
+    const summary = { working: 0, idle: 0, blocked: 0, total: Object.keys(agentData).length }
+    for (const agent of Object.values(agentData)) {
+      if (agent.status === 'working') summary.working++
+      else if (agent.status === 'blocked') summary.blocked++
+      else summary.idle++
+    }
+
+    const snapshot = { agents: agentData, summary }
+
+    if (skipIfUnchanged('agents', snapshot)) return
+    const ts = new Date().toISOString()
+    insertSnapshot('agents', ts, snapshot, dataHash(snapshot))
+    log.info('Agent snapshot saved', summary)
+  } catch (err) {
+    log.error('Agent snapshot failed', { error: err.message })
+  }
+}
+
+// --- GitHub Actions Snapshots ---
+
+async function snapshotActions() {
+  try {
+    const actionsData = { totalRuns: 0, repos: {} }
+
+    for (const repo of REPOS) {
+      const [owner, name] = repo.github.split('/')
+      try {
+        const { data } = await githubFetch(
+          `/repos/${owner}/${name}/actions/runs?per_page=10&status=completed`
+        )
+        const runs = data.workflow_runs || []
+        let durationMs = 0
+        for (const run of runs) {
+          if (run.created_at && run.updated_at) {
+            const d = new Date(run.updated_at).getTime() - new Date(run.created_at).getTime()
+            if (d > 0) durationMs += d
+          }
+        }
+        actionsData.repos[repo.id] = {
+          runs: runs.length,
+          durationMinutes: Math.round(durationMs / 60_000),
+        }
+        actionsData.totalRuns += runs.length
+      } catch (err) {
+        log.warn('Failed to snapshot actions for repo', { repo: repo.id, error: err.message })
+      }
+    }
+
+    if (skipIfUnchanged('actions', actionsData)) return
+    const ts = new Date().toISOString()
+    insertSnapshot('actions', ts, actionsData, dataHash(actionsData))
+    log.info('Actions snapshot saved', { totalRuns: actionsData.totalRuns })
+  } catch (err) {
+    log.error('Actions snapshot failed', { error: err.message })
+  }
+}
+
+// --- Daily Summary ---
+
+async function computeDailySummary() {
+  const today = new Date().toISOString().slice(0, 10)
+  if (lastDailySummaryDate === today) return
+
+  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+  if (lastDailySummaryDate === yesterday) return
+
+  try {
+    const from = `${yesterday}T00:00:00.000Z`
+    const to = `${yesterday}T23:59:59.999Z`
+
+    for (const channel of ['issues', 'agents', 'actions']) {
+      const snapshots = querySnapshots(channel, from, to, '5m')
+      if (!snapshots.length) continue
+
+      const first = snapshots[0].data
+      const last = snapshots[snapshots.length - 1].data
+      const summary = {
+        snapshotCount: snapshots.length,
+        firstSnapshot: first,
+        lastSnapshot: last,
+      }
+
+      upsertDailySummary(yesterday, channel, summary)
+    }
+
+    pruneOldSnapshots()
+    lastDailySummaryDate = yesterday
+    log.info('Daily summary computed', { date: yesterday })
+  } catch (err) {
+    log.error('Daily summary computation failed', { error: err.message })
+  }
+}
+
+// --- Service Lifecycle ---
+
+export function startSnapshotService() {
+  log.info('Starting snapshot service', {
+    issueInterval: '5m',
+    agentInterval: '5m',
+    actionsInterval: '15m',
+  })
+
+  // Run initial snapshots after a short delay (let server start)
+  setTimeout(() => {
+    snapshotIssues()
+    snapshotAgents()
+    snapshotActions()
+    computeDailySummary()
+  }, 10_000)
+
+  timers.issues = setInterval(snapshotIssues, INTERVALS.issues)
+  timers.agents = setInterval(snapshotAgents, INTERVALS.agents)
+  timers.actions = setInterval(snapshotActions, INTERVALS.actions)
+  // Check daily summary every hour
+  timers.daily = setInterval(computeDailySummary, 60 * 60 * 1000)
+}
+
+export function stopSnapshotService() {
+  for (const [name, timer] of Object.entries(timers)) {
+    clearInterval(timer)
+    delete timers[name]
+  }
+  log.info('Snapshot service stopped')
+}
+
+// Export for testing
+export { snapshotIssues, snapshotAgents, snapshotActions, computeDailySummary }


### PR DESCRIPTION
Closes #79

## Summary

Adds a complete historical metrics persistence layer using SQLite (better-sqlite3), enabling time-series data collection and querying for the squad monitor dashboard.

### New Files

- **\server/lib/metrics-db.js\** — SQLite database module
  - Tables: \metrics_snapshots\ (id, timestamp, channel, data JSON, hash, created_at) + \daily_summaries\ (date, channel, summary JSON)
  - Index on (channel, timestamp) for fast time-series queries
  - WAL mode for concurrent read performance
  - Auto-create in \data/metrics.sqlite\, auto-migrate schema
  - 30-day retention: raw snapshots pruned, daily summaries kept forever
  - \METRICS_DB_PATH\ env var for custom path

- **\server/lib/snapshot-service.js\** — Scheduled data collection
  - Every 5min: snapshot issue counts (open/closed per repo) and agent status (working/idle/blocked)
  - Every 15min: snapshot GitHub Actions usage
  - Hourly: compute daily summary for yesterday, prune old data
  - Skip-if-unchanged: SHA-256 hash comparison prevents duplicate snapshots

- **\server/api/metrics.js\** — Four new API endpoints
  - \GET /api/metrics?channel=issues&from=&to=&interval=1h\ — time-series data with interval aggregation (5m/15m/1h/6h/1d)
  - \GET /api/metrics/summary?date=2026-03-13\ — daily summary
  - \GET /api/metrics/agents?from=&to=\ — per-agent metrics history
  - \GET /api/metrics/stats\ — database size and counts

### Modified Files

- **\server/index.js\** — Wire 4 new routes, start/stop snapshot service on server lifecycle, add metricsDb to /health
- **\server/api/health.js\** — Add metricsDb stats to /api/health dependencies
- **\.gitignore\** — Add \data/\ directory
- **\package.json\** — Add \etter-sqlite3\ dependency

### Design Decisions

- **better-sqlite3 (synchronous)** over async alternatives — simpler, faster for single-process server, no callback complexity
- **Hash-based dedup** — prevents filling the DB with identical snapshots when nothing changes
- **Interval aggregation** — takes last snapshot per bucket, enabling efficient zoomed-out views
- **Daily summaries preserved forever** — raw data pruned after 30 days, but daily summaries are permanent for long-term trends