### PR TITLE
feat: SSE event bus infrastructure for real-time data streaming

### DIFF
--- a/server/api/health.js
+++ b/server/api/health.js
@@ -3,6 +3,7 @@ import { config } from '../config.js'
 import { getRateLimitStatus, githubFetch } from '../lib/github-client.js'
 import { getHeartbeatResponse } from './heartbeat.js'
 import { getDbStats } from '../lib/metrics-db.js'
+import { eventBus } from '../lib/event-bus.js'
 import { logger } from '../lib/logger.js'
 
 let lastGithubCheck = null
@@ -76,6 +77,7 @@ export default async function healthRoute(req, res) {
         try { return getDbStats() } catch { return null }
       })(),
     },
+    sse: eventBus.getConnectionInfo(),
   })
 }
 

--- a/server/api/heartbeat.js
+++ b/server/api/heartbeat.js
@@ -1,12 +1,14 @@
 import fs from 'fs';
 import path from 'path';
 import { config } from '../config.js';
+import { eventBus } from '../lib/event-bus.js';
 
 // Cached heartbeat state — updated via fs.watch
 let heartbeatCache = null;
 let heartbeatWatcher = null;
 
 function readHeartbeatFile() {
+  const prevCache = heartbeatCache;
   try {
     const raw = fs.readFileSync(config.heartbeatPath, 'utf-8').replace(/^\uFEFF/, '');
     const data = JSON.parse(raw);
@@ -24,6 +26,11 @@ function readHeartbeatFile() {
     };
   } catch {
     heartbeatCache = null;
+  }
+
+  // Publish to event bus when heartbeat data changes
+  if (heartbeatCache && JSON.stringify(heartbeatCache) !== JSON.stringify(prevCache)) {
+    eventBus.publish('heartbeat', 'heartbeat:update', heartbeatCache);
   }
 }
 

--- a/server/api/sse.js
+++ b/server/api/sse.js
@@ -1,0 +1,83 @@
+import { eventBus, CHANNELS } from '../lib/event-bus.js'
+import { logger } from '../lib/logger.js'
+
+const log = logger.child({ component: 'sse' })
+
+let connectionCounter = 0
+
+export default function sseRoute(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`)
+  const channelsParam = url.searchParams.get('channels') || ''
+  const requested = channelsParam
+    .split(',')
+    .map(c => c.trim())
+    .filter(c => CHANNELS.includes(c))
+
+  if (requested.length === 0) {
+    res.status(400).json({
+      error: 'No valid channels specified',
+      available: CHANNELS,
+      usage: '/api/sse?channels=heartbeat,events',
+    })
+    return
+  }
+
+  res.setHeader('Content-Type', 'text/event-stream')
+  res.setHeader('Cache-Control', 'no-cache')
+  res.setHeader('Connection', 'keep-alive')
+  res.setHeader('X-Accel-Buffering', 'no')
+  res.setHeader('Access-Control-Allow-Origin', '*')
+  res.flushHeaders?.()
+
+  const connectionId = `sse-${++connectionCounter}-${Date.now()}`
+
+  const lastEventId = req.headers['last-event-id']
+    ? parseInt(req.headers['last-event-id'], 10)
+    : null
+
+  eventBus.addConnection(connectionId, requested)
+
+  res.write(`event: connected\ndata: ${JSON.stringify({
+    connectionId,
+    channels: requested,
+    lastEventId,
+    timestamp: new Date().toISOString(),
+  })}\n\n`)
+
+  log.info('SSE client connected', { connectionId, channels: requested, lastEventId })
+
+  const listeners = new Map()
+
+  for (const channel of requested) {
+    const handler = (event) => {
+      if (lastEventId !== null && parseInt(event.id, 10) <= lastEventId) return
+
+      try {
+        res.write(`id: ${event.id}\nevent: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+      } catch {
+        // Connection closed
+      }
+    }
+
+    eventBus.on(channel, handler)
+    listeners.set(channel, handler)
+  }
+
+  const keepalive = setInterval(() => {
+    try {
+      res.write(': keepalive\n\n')
+    } catch {
+      // Connection closed
+    }
+  }, 15_000)
+
+  req.on('close', () => {
+    clearInterval(keepalive)
+    for (const [channel, handler] of listeners) {
+      eventBus.removeListener(channel, handler)
+    }
+    listeners.clear()
+    eventBus.removeConnection(connectionId)
+    log.info('SSE client disconnected', { connectionId })
+  })
+}

--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import { config } from './config.js';
 import { getRateLimitStatus } from './lib/github-client.js';
+import { eventBus } from './lib/event-bus.js';
 import { logger, requestLogger } from './lib/logger.js';
 import { startSnapshotService, stopSnapshotService } from './lib/snapshot-service.js';
 import { closeDb, getDbStats } from './lib/metrics-db.js';
@@ -19,6 +20,7 @@ import eventsRoute from './api/events.js';
 import usageRoute from './api/usage.js';
 import healthRoute from './api/health.js';
 import { metricsRoute, metricsSummaryRoute, metricsAgentsRoute, metricsStatsRoute } from './api/metrics.js';
+import sseRoute from './api/sse.js';
 
 const app = express();
 
@@ -45,6 +47,7 @@ app.get('/api/metrics', metricsRoute);
 app.get('/api/metrics/summary', metricsSummaryRoute);
 app.get('/api/metrics/agents', metricsAgentsRoute);
 app.get('/api/metrics/stats', metricsStatsRoute);
+app.get('/api/sse', sseRoute);
 
 // Health check with rate limit status
 app.get('/health', (req, res) => {
@@ -66,6 +69,7 @@ app.get('/health', (req, res) => {
       },
     },
     metricsDb: dbStats,
+    sse: eventBus.getConnectionInfo(),
   });
 });
 
@@ -93,7 +97,7 @@ app.listen(PORT, () => {
       '/api/timeline', '/api/issues', '/api/pulse', '/api/agents',
       '/api/repos', '/api/config', '/api/events', '/api/usage', '/api/health',
       '/api/metrics', '/api/metrics/summary', '/api/metrics/agents', '/api/metrics/stats',
-      '/health',
+      '/api/sse', '/health',
     ],
   });
 

--- a/server/lib/__tests__/event-bus.test.js
+++ b/server/lib/__tests__/event-bus.test.js
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../logger.js', () => ({
+  logger: {
+    child: () => ({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { EventBus, CHANNELS, eventBus } from '../event-bus.js'
+
+describe('CHANNELS', () => {
+  it('exports all expected channel names', () => {
+    expect(CHANNELS).toContain('heartbeat')
+    expect(CHANNELS).toContain('events')
+    expect(CHANNELS).toContain('issues')
+    expect(CHANNELS).toContain('usage')
+    expect(CHANNELS).toContain('agents')
+    expect(CHANNELS).toContain('alerts')
+    expect(CHANNELS).toHaveLength(6)
+  })
+})
+
+describe('EventBus', () => {
+  let bus
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    bus = new EventBus()
+  })
+
+  afterEach(() => {
+    bus.destroy()
+    vi.useRealTimers()
+  })
+
+  describe('publish / subscribe', () => {
+    it('emits event on valid channel', () => {
+      const handler = vi.fn()
+      bus.on('heartbeat', handler)
+      bus.publish('heartbeat', 'heartbeat:update', { status: 'running' })
+      expect(handler).toHaveBeenCalledOnce()
+      const event = handler.mock.calls[0][0]
+      expect(event.type).toBe('heartbeat:update')
+      expect(event.channel).toBe('heartbeat')
+      expect(event.data).toEqual({ status: 'running' })
+      expect(event.id).toBe('1')
+      expect(event.timestamp).toBeTruthy()
+    })
+
+    it('ignores publish to unknown channel', () => {
+      const handler = vi.fn()
+      bus.on('unknown', handler)
+      bus.publish('unknown', 'unknown:event', {})
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('increments event IDs', () => {
+      const handler = vi.fn()
+      bus.on('heartbeat', handler)
+      bus.publish('heartbeat', 'heartbeat:update', { round: 1 })
+      vi.advanceTimersByTime(1100)
+      bus.publish('heartbeat', 'heartbeat:update', { round: 2 })
+      expect(handler).toHaveBeenCalledTimes(2)
+      expect(handler.mock.calls[0][0].id).toBe('1')
+      expect(handler.mock.calls[1][0].id).toBe('2')
+    })
+
+    it('publishes to multiple channels independently', () => {
+      const hbHandler = vi.fn()
+      const alertHandler = vi.fn()
+      bus.on('heartbeat', hbHandler)
+      bus.on('alerts', alertHandler)
+      bus.publish('heartbeat', 'heartbeat:update', { status: 'idle' })
+      bus.publish('alerts', 'alerts:new', { message: 'test' })
+      expect(hbHandler).toHaveBeenCalledOnce()
+      expect(alertHandler).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('rate limiting (debounce)', () => {
+    it('debounces rapid events on same channel', () => {
+      const handler = vi.fn()
+      bus.on('heartbeat', handler)
+      bus.publish('heartbeat', 'heartbeat:update', { round: 1 })
+      expect(handler).toHaveBeenCalledOnce()
+      bus.publish('heartbeat', 'heartbeat:update', { round: 2 })
+      expect(handler).toHaveBeenCalledOnce()
+      vi.advanceTimersByTime(1100)
+      expect(handler).toHaveBeenCalledTimes(2)
+      expect(handler.mock.calls[1][0].data.round).toBe(2)
+    })
+
+    it('coalesces multiple rapid events - only last fires', () => {
+      const handler = vi.fn()
+      bus.on('heartbeat', handler)
+      bus.publish('heartbeat', 'heartbeat:update', { round: 1 })
+      bus.publish('heartbeat', 'heartbeat:update', { round: 2 })
+      bus.publish('heartbeat', 'heartbeat:update', { round: 3 })
+      vi.advanceTimersByTime(1100)
+      expect(handler).toHaveBeenCalledTimes(2)
+      expect(handler.mock.calls[1][0].data.round).toBe(3)
+    })
+
+    it('does not debounce across different channels', () => {
+      const hbHandler = vi.fn()
+      const alertHandler = vi.fn()
+      bus.on('heartbeat', hbHandler)
+      bus.on('alerts', alertHandler)
+      bus.publish('heartbeat', 'heartbeat:update', { status: 'running' })
+      bus.publish('alerts', 'alerts:new', { message: 'alert' })
+      expect(hbHandler).toHaveBeenCalledOnce()
+      expect(alertHandler).toHaveBeenCalledOnce()
+    })
+
+    it('allows events after debounce period expires', () => {
+      const handler = vi.fn()
+      bus.on('heartbeat', handler)
+      bus.publish('heartbeat', 'heartbeat:update', { round: 1 })
+      vi.advanceTimersByTime(1100)
+      bus.publish('heartbeat', 'heartbeat:update', { round: 2 })
+      expect(handler).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('connection tracking', () => {
+    it('tracks connections and provides count', () => {
+      expect(bus.connectionCount).toBe(0)
+      bus.addConnection('conn-1', ['heartbeat', 'events'])
+      expect(bus.connectionCount).toBe(1)
+      bus.addConnection('conn-2', ['alerts'])
+      expect(bus.connectionCount).toBe(2)
+    })
+
+    it('removes connections', () => {
+      bus.addConnection('conn-1', ['heartbeat'])
+      bus.addConnection('conn-2', ['events'])
+      expect(bus.connectionCount).toBe(2)
+      bus.removeConnection('conn-1')
+      expect(bus.connectionCount).toBe(1)
+      bus.removeConnection('conn-2')
+      expect(bus.connectionCount).toBe(0)
+    })
+
+    it('handles removing non-existent connection gracefully', () => {
+      expect(() => bus.removeConnection('nonexistent')).not.toThrow()
+    })
+  })
+
+  describe('getConnectionInfo', () => {
+    it('returns channel breakdown', () => {
+      bus.addConnection('conn-1', ['heartbeat', 'events'])
+      bus.addConnection('conn-2', ['heartbeat', 'alerts'])
+      bus.addConnection('conn-3', ['events'])
+      const info = bus.getConnectionInfo()
+      expect(info.total).toBe(3)
+      expect(info.byChannel.heartbeat).toBe(2)
+      expect(info.byChannel.events).toBe(2)
+      expect(info.byChannel.alerts).toBe(1)
+      expect(info.byChannel.issues).toBe(0)
+      expect(info.byChannel.usage).toBe(0)
+      expect(info.byChannel.agents).toBe(0)
+    })
+
+    it('returns zeros when no connections', () => {
+      const info = bus.getConnectionInfo()
+      expect(info.total).toBe(0)
+      for (const ch of CHANNELS) {
+        expect(info.byChannel[ch]).toBe(0)
+      }
+    })
+  })
+
+  describe('currentEventId', () => {
+    it('tracks current event ID', () => {
+      expect(bus.currentEventId).toBe(0)
+      bus.publish('heartbeat', 'heartbeat:update', {})
+      expect(bus.currentEventId).toBe(1)
+      vi.advanceTimersByTime(1100)
+      bus.publish('events', 'events:new', {})
+      expect(bus.currentEventId).toBe(2)
+    })
+  })
+
+  describe('destroy', () => {
+    it('clears all state', () => {
+      bus.addConnection('conn-1', ['heartbeat'])
+      bus.publish('heartbeat', 'heartbeat:update', {})
+      bus.destroy()
+      expect(bus.connectionCount).toBe(0)
+      expect(bus.currentEventId).toBe(0)
+      expect(bus.listenerCount('heartbeat')).toBe(0)
+    })
+
+    it('clears pending debounce timers', () => {
+      const handler = vi.fn()
+      bus.on('heartbeat', handler)
+      bus.publish('heartbeat', 'heartbeat:update', { round: 1 })
+      bus.publish('heartbeat', 'heartbeat:update', { round: 2 })
+      bus.destroy()
+      vi.advanceTimersByTime(2000)
+      expect(handler).toHaveBeenCalledOnce()
+    })
+  })
+})
+
+describe('eventBus singleton', () => {
+  it('exports a singleton EventBus instance', () => {
+    expect(eventBus).toBeInstanceOf(EventBus)
+  })
+})

--- a/server/lib/event-bus.js
+++ b/server/lib/event-bus.js
@@ -1,0 +1,114 @@
+import { EventEmitter } from 'events'
+import { logger } from './logger.js'
+
+export const CHANNELS = [
+  'heartbeat',
+  'events',
+  'issues',
+  'usage',
+  'agents',
+  'alerts',
+]
+
+const DEBOUNCE_MS = 1000
+
+export class EventBus extends EventEmitter {
+  constructor() {
+    super()
+    this.setMaxListeners(200)
+    this._connections = new Map()
+    this._lastEmitTime = new Map()
+    this._pendingEvents = new Map()
+    this._eventId = 0
+    this._log = logger.child({ component: 'event-bus' })
+  }
+
+  publish(channel, type, data) {
+    if (!CHANNELS.includes(channel)) {
+      this._log.warn('Unknown channel', { channel, type })
+      return
+    }
+
+    const event = {
+      id: String(++this._eventId),
+      type,
+      channel,
+      data,
+      timestamp: new Date().toISOString(),
+    }
+
+    const now = Date.now()
+    const lastTime = this._lastEmitTime.get(channel) || 0
+    const elapsed = now - lastTime
+
+    if (elapsed >= DEBOUNCE_MS) {
+      this._lastEmitTime.set(channel, now)
+      this._dispatch(channel, event)
+    } else {
+      const existing = this._pendingEvents.get(channel)
+      if (existing) clearTimeout(existing.timer)
+
+      const delay = DEBOUNCE_MS - elapsed
+      const timer = setTimeout(() => {
+        this._lastEmitTime.set(channel, Date.now())
+        this._pendingEvents.delete(channel)
+        this._dispatch(channel, event)
+      }, delay)
+
+      this._pendingEvents.set(channel, { event, timer })
+    }
+  }
+
+  _dispatch(channel, event) {
+    this.emit(channel, event)
+    this._log.debug('Event dispatched', { channel, type: event.type, id: event.id })
+  }
+
+  addConnection(connectionId, channels) {
+    this._connections.set(connectionId, {
+      channels,
+      connectedAt: new Date().toISOString(),
+    })
+    this._log.info('SSE connection added', { connectionId, channels, total: this._connections.size })
+  }
+
+  removeConnection(connectionId) {
+    this._connections.delete(connectionId)
+    this._log.info('SSE connection removed', { connectionId, total: this._connections.size })
+  }
+
+  get connectionCount() {
+    return this._connections.size
+  }
+
+  get currentEventId() {
+    return this._eventId
+  }
+
+  getConnectionInfo() {
+    const channelCounts = {}
+    for (const ch of CHANNELS) channelCounts[ch] = 0
+    for (const [, conn] of this._connections) {
+      for (const ch of conn.channels) {
+        if (channelCounts[ch] !== undefined) channelCounts[ch]++
+      }
+    }
+    return {
+      total: this._connections.size,
+      byChannel: channelCounts,
+    }
+  }
+
+  destroy() {
+    for (const [, pending] of this._pendingEvents) {
+      clearTimeout(pending.timer)
+    }
+    this._pendingEvents.clear()
+    this._connections.clear()
+    this.removeAllListeners()
+    this._eventId = 0
+    this._lastEmitTime.clear()
+  }
+}
+
+export const eventBus = new EventBus()

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -7,11 +7,14 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     setupFiles: ['./src/components/__tests__/setup.js'],
+    environmentMatchGlobs: [
+      ['server/**', 'node'],
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      include: ['src/lib/**/*.js', 'src/services/**/*.js', 'src/components/**/*.jsx'],
-      exclude: ['src/lib/**/*.test.js', 'src/lib/__tests__/**', 'src/services/**/*.test.js', 'src/services/__tests__/**', 'src/components/__tests__/**'],
+      include: ['src/lib/**/*.js', 'src/services/**/*.js', 'src/components/**/*.jsx', 'server/lib/**/*.js'],
+      exclude: ['src/lib/**/*.test.js', 'src/lib/__tests__/**', 'src/services/**/*.test.js', 'src/services/__tests__/**', 'src/components/__tests__/**', 'server/**/__tests__/**'],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
Closes #75

## Summary

Adds SSE event bus infrastructure for real-time data streaming, replacing polling for time-sensitive data channels.

### New Files
- **\server/lib/event-bus.js\** — EventEmitter-based pub/sub with 6 typed channels (heartbeat, events, issues, usage, agents, alerts), rate limiting (max 1 event/channel/sec), connection tracking, and cleanup
- **\server/api/sse.js\** — SSE endpoint at \GET /api/sse?channels=heartbeat,events\ with multi-channel subscriptions, \Last-Event-ID\ reconnection support, 15s keep-alive, proper \	ext/event-stream\ headers + CORS
- **\server/lib/__tests__/event-bus.test.js\** — 18 unit tests covering pub/sub, debounce, connection tracking, channel breakdown, cleanup

### Modified Files
- **\server/api/heartbeat.js\** — Heartbeat file watcher now publishes to event bus on change (delta detection via JSON comparison)
- **\server/api/health.js\** — \/api/health\ includes SSE connection count and per-channel breakdown
- **\server/index.js\** — Registers \/api/sse\ route, adds SSE info to \/health\ endpoint
- **\itest.config.js\** — Server tests run in \
ode\ environment via \nvironmentMatchGlobs\

### Acceptance Criteria
- [x] \server/lib/event-bus.js\ with typed channels
- [x] \server/api/sse.js\ handling multi-channel subscriptions
- [x] Heartbeat watcher publishes to event bus
- [x] Keep-alive mechanism (15s interval)
- [x] \/health\ shows SSE connection count
- [x] Existing polling endpoints unchanged
- [x] Unit tests for event bus pub/sub logic (18 tests)