### PR TITLE
feat: OpenAPI/Swagger documentation for all API endpoints

### DIFF
--- a/server/api/board.js
+++ b/server/api/board.js
@@ -5,6 +5,43 @@ const ISSUE_CACHE_TTL = config.issueCacheTTL;
 let issueCache = null;
 let issueCacheTime = 0;
 
+/**
+ * @openapi
+ * /api/issues:
+ *   get:
+ *     summary: Get issues across all repos
+ *     description: Fetches GitHub issues from all monitored repositories, sorted by priority then update time. Includes linked PR status. Default (open) queries are cached for 30 seconds.
+ *     tags: [Issues]
+ *     parameters:
+ *       - in: query
+ *         name: state
+ *         schema:
+ *           type: string
+ *           enum: [open, closed, all]
+ *           default: open
+ *         description: Filter issues by state
+ *     responses:
+ *       200:
+ *         description: Array of issues across all repos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Issue'
+ *       500:
+ *         description: Failed to fetch issues
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       503:
+ *         description: GitHub API rate limit exceeded
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 export default async function boardRoute(req, res) {
   try {
     const url = new URL(req.url, `http://${req.headers.host}`);

--- a/server/api/config.js
+++ b/server/api/config.js
@@ -1,5 +1,30 @@
 import { REPOS, SQUAD_AGENTS } from '../config.js';
 
+/**
+ * @openapi
+ * /api/config:
+ *   get:
+ *     summary: Get dashboard configuration
+ *     description: Returns monitored repos and squad agent roster. Repos include owner/name split from the github slug. Agent config includes emoji, role, color, and assigned repo.
+ *     tags: [Config]
+ *     responses:
+ *       200:
+ *         description: Dashboard configuration
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 repos:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/ConfigRepo'
+ *                 agents:
+ *                   type: object
+ *                   description: Agent roster keyed by agent ID
+ *                   additionalProperties:
+ *                     $ref: '#/components/schemas/ConfigAgent'
+ */
 export default function configRoute(req, res) {
   const repos = REPOS.map(repo => {
     const [owner, name] = repo.github.split('/');

--- a/server/api/events.js
+++ b/server/api/events.js
@@ -5,6 +5,35 @@ const CACHE_TTL = 30_000
 let eventsCache = null
 let eventsCacheTime = 0
 
+/**
+ * @openapi
+ * /api/events:
+ *   get:
+ *     summary: Get recent GitHub events
+ *     description: Aggregates recent GitHub events across all monitored repositories. Cached for 30 seconds. Returns up to 100 events sorted by most recent first.
+ *     tags: [Events]
+ *     responses:
+ *       200:
+ *         description: Array of recent GitHub events
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Event'
+ *       500:
+ *         description: Failed to fetch events
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       503:
+ *         description: GitHub API rate limit exceeded
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 export default async function eventsRoute(req, res) {
   try {
     if (eventsCache && Date.now() - eventsCacheTime < CACHE_TTL) {

--- a/server/api/health.js
+++ b/server/api/health.js
@@ -36,6 +36,21 @@ function checkHeartbeatFile() {
   }
 }
 
+/**
+ * @openapi
+ * /api/health:
+ *   get:
+ *     summary: Detailed health check
+ *     description: Returns comprehensive health status including GitHub API reachability, heartbeat file accessibility, rate limit info, metrics DB stats, and SSE connection count.
+ *     tags: [Health]
+ *     responses:
+ *       200:
+ *         description: Health check response
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/HealthCheck'
+ */
 export default async function healthRoute(req, res) {
   const rl = getRateLimitStatus()
   const heartbeatFile = checkHeartbeatFile()

--- a/server/api/heartbeat.js
+++ b/server/api/heartbeat.js
@@ -64,6 +64,21 @@ export function getHeartbeatResponse() {
 readHeartbeatFile();
 startWatcher();
 
+/**
+ * @openapi
+ * /api/heartbeat:
+ *   get:
+ *     summary: Get current heartbeat status
+ *     description: Returns the latest Ralph scheduler heartbeat data, read from the `.ralph-heartbeat.json` file. Updated in real-time via file watcher.
+ *     tags: [Heartbeat]
+ *     responses:
+ *       200:
+ *         description: Current heartbeat data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Heartbeat'
+ */
 export default function heartbeatRoute(req, res) {
   res.setHeader('Content-Type', 'application/json');
   res.end(JSON.stringify(getHeartbeatResponse()));

--- a/server/api/logs.js
+++ b/server/api/logs.js
@@ -39,6 +39,48 @@ export function readLogEntries(agent, date) {
   } catch { return []; }
 }
 
+/**
+ * @openapi
+ * /api/logs/files:
+ *   get:
+ *     summary: List available log files
+ *     description: Returns lists of available agents, dates, and log files for use in date/agent pickers.
+ *     tags: [Logs]
+ *     responses:
+ *       200:
+ *         description: Available log files metadata
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 agents:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                   example: [ralph, solo, moe]
+ *                 dates:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                     format: date
+ *                   example: ['2026-03-13', '2026-03-12']
+ *                 files:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       file:
+ *                         type: string
+ *                         example: ralph-2026-03-13.jsonl
+ *                       agent:
+ *                         type: string
+ *                         example: ralph
+ *                       date:
+ *                         type: string
+ *                         format: date
+ *                         example: '2026-03-13'
+ */
 // List available log files (for date/agent pickers)
 export function logsFilesRoute(req, res) {
   const files = listLogFiles();
@@ -48,6 +90,31 @@ export function logsFilesRoute(req, res) {
   res.end(JSON.stringify({ agents, dates, files }));
 }
 
+/**
+ * @openapi
+ * /api/logs/stream:
+ *   get:
+ *     summary: Stream log entries in real-time
+ *     description: |
+ *       SSE endpoint that streams new log entries as they are written. Watches the logs directory for file changes.
+ *       Sends all existing entries on connect, then new entries as they appear. Keepalive every 15 seconds.
+ *     tags: [Logs]
+ *     parameters:
+ *       - in: query
+ *         name: since
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: Only stream entries newer than this timestamp
+ *     responses:
+ *       200:
+ *         description: SSE stream of log entries
+ *         content:
+ *           text/event-stream:
+ *             schema:
+ *               type: string
+ *               description: Each data event contains a JSON LogEntry object
+ */
 // SSE endpoint — streams new log entries in real time
 export function logsStreamRoute(req, res) {
   res.setHeader('Content-Type', 'text/event-stream');
@@ -128,6 +195,43 @@ export function logsStreamRoute(req, res) {
   });
 }
 
+/**
+ * @openapi
+ * /api/logs:
+ *   get:
+ *     summary: Get structured log entries
+ *     description: Returns parsed JSONL log entries for a given date and optional agent filter. Falls back to latest available date if no logs exist for today.
+ *     tags: [Logs]
+ *     parameters:
+ *       - in: query
+ *         name: date
+ *         schema:
+ *           type: string
+ *           format: date
+ *           example: '2026-03-13'
+ *         description: Date in YYYY-MM-DD format. Defaults to today.
+ *       - in: query
+ *         name: agent
+ *         schema:
+ *           type: string
+ *           example: ralph
+ *         description: Filter by agent name
+ *     responses:
+ *       200:
+ *         description: Array of log entries sorted by timestamp
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/LogEntry'
+ *       500:
+ *         description: Failed to read logs
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 // Structured logs — supports ?date=YYYY-MM-DD&agent=name query params
 export default function logsRoute(req, res) {
   try {

--- a/server/api/pulse.js
+++ b/server/api/pulse.js
@@ -2,6 +2,27 @@ import fs from 'fs';
 import { config, REPOS, SQUAD_AGENTS } from '../config.js';
 import { githubFetch, handleGitHubError } from '../lib/github-client.js';
 
+/**
+ * @openapi
+ * /api/pulse:
+ *   get:
+ *     summary: Get daily activity pulse
+ *     description: Returns today's activity counts — PRs merged, issues closed, active agents, and total agent roster size.
+ *     tags: [Pulse]
+ *     responses:
+ *       200:
+ *         description: Daily pulse data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Pulse'
+ *       500:
+ *         description: Failed to compute pulse
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 export default async function pulseRoute(req, res) {
   try {
     let prsMergedToday = 0;

--- a/server/api/repos.js
+++ b/server/api/repos.js
@@ -46,6 +46,29 @@ function getLastCommit(repoDir) {
   } catch { return null; }
 }
 
+/**
+ * @openapi
+ * /api/repos:
+ *   get:
+ *     summary: Get monitored repositories
+ *     description: Returns status info for each monitored repo including squad presence, current focus from now.md, open issue count, and latest commit.
+ *     tags: [Repos]
+ *     responses:
+ *       200:
+ *         description: Array of repository status objects
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Repo'
+ *       500:
+ *         description: Failed to fetch repos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 export default async function reposRoute(req, res) {
   try {
     const results = [];

--- a/server/api/sse.js
+++ b/server/api/sse.js
@@ -5,6 +5,49 @@ const log = logger.child({ component: 'sse' })
 
 let connectionCounter = 0
 
+/**
+ * @openapi
+ * /api/sse:
+ *   get:
+ *     summary: SSE event stream
+ *     description: |
+ *       Server-Sent Events endpoint for real-time updates. Subscribe to one or more channels.
+ *       Sends keepalive comments every 15 seconds. Supports `Last-Event-ID` header for reconnection.
+ *     tags: [SSE]
+ *     parameters:
+ *       - in: query
+ *         name: channels
+ *         required: true
+ *         schema:
+ *           type: string
+ *           example: 'heartbeat,events'
+ *         description: Comma-separated list of channels to subscribe to
+ *     responses:
+ *       200:
+ *         description: SSE event stream
+ *         content:
+ *           text/event-stream:
+ *             schema:
+ *               type: string
+ *               description: Server-Sent Events stream with event types matching subscribed channels
+ *       400:
+ *         description: No valid channels specified
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: 'No valid channels specified'
+ *                 available:
+ *                   type: array
+ *                   items:
+ *                     type: string
+ *                 usage:
+ *                   type: string
+ *                   example: '/api/sse?channels=heartbeat,events'
+ */
 export default function sseRoute(req, res) {
   const url = new URL(req.url, `http://${req.headers.host}`)
   const channelsParam = url.searchParams.get('channels') || ''

--- a/server/api/timeline.js
+++ b/server/api/timeline.js
@@ -1,6 +1,35 @@
 import { listLogFiles, readLogEntries } from './logs.js';
 import { getHeartbeatResponse } from './heartbeat.js';
 
+/**
+ * @openapi
+ * /api/timeline:
+ *   get:
+ *     summary: Get daily round timeline
+ *     description: Returns structured log rounds for a given date, plus summary statistics and current heartbeat state. Falls back to latest available date if no logs exist for today.
+ *     tags: [Timeline]
+ *     parameters:
+ *       - in: query
+ *         name: date
+ *         schema:
+ *           type: string
+ *           format: date
+ *           example: '2026-03-13'
+ *         description: Date in YYYY-MM-DD format. Defaults to today.
+ *     responses:
+ *       200:
+ *         description: Timeline data for the requested date
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Timeline'
+ *       500:
+ *         description: Failed to build timeline
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 export default function timelineRoute(req, res) {
   try {
     const url = new URL(req.url, `http://${req.headers.host}`);

--- a/server/api/usage.js
+++ b/server/api/usage.js
@@ -101,6 +101,27 @@ async function fetchUsageData() {
   }
 }
 
+/**
+ * @openapi
+ * /api/usage:
+ *   get:
+ *     summary: Get GitHub Actions usage
+ *     description: Returns CI/CD usage data. Tries org billing API first, falls back to aggregating workflow run durations across repos. Cached for 30 seconds.
+ *     tags: [Usage]
+ *     responses:
+ *       200:
+ *         description: Usage data (billing or aggregated workflow runs)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Usage'
+ *       500:
+ *         description: Failed to fetch usage data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
 export default async function usageRoute(req, res) {
   try {
     if (usageCache && Date.now() - usageCacheTime < CACHE_TTL) {

--- a/server/api/workflows.js
+++ b/server/api/workflows.js
@@ -51,6 +51,23 @@ function getOrchestrationActivity() {
   return activity;
 }
 
+/**
+ * @openapi
+ * /api/agents:
+ *   get:
+ *     summary: Get squad agent statuses
+ *     description: Returns all squad agents with their current status (idle, working, blocked), last activity timestamp, and current work description. Sources data from orchestration logs and JSONL logs.
+ *     tags: [Agents]
+ *     responses:
+ *       200:
+ *         description: Array of agent status objects
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Agent'
+ */
 export default function workflowsRoute(req, res) {
   const orchestration = getOrchestrationActivity();
 

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ import { eventBus } from './lib/event-bus.js';
 import { logger, requestLogger } from './lib/logger.js';
 import { startSnapshotService, stopSnapshotService } from './lib/snapshot-service.js';
 import { closeDb, getDbStats } from './lib/metrics-db.js';
+import { setupSwagger } from './lib/swagger.js';
 
 // Import route handlers
 import heartbeatRoute from './api/heartbeat.js';
@@ -29,6 +30,9 @@ app.use(cors());
 app.use(express.json());
 app.use(requestLogger);
 
+// Swagger UI at /api/docs
+setupSwagger(app);
+
 // API routes
 app.get('/api/heartbeat', heartbeatRoute);
 app.get('/api/logs/files', logsFilesRoute);
@@ -49,6 +53,21 @@ app.get('/api/metrics/agents', metricsAgentsRoute);
 app.get('/api/metrics/stats', metricsStatsRoute);
 app.get('/api/sse', sseRoute);
 
+/**
+ * @openapi
+ * /health:
+ *   get:
+ *     summary: Simple health check
+ *     description: Quick health endpoint returning server status, GitHub auth state, rate limit info, and metrics DB stats. Lighter than /api/health — no external calls.
+ *     tags: [Health]
+ *     responses:
+ *       200:
+ *         description: Server health status
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SimpleHealth'
+ */
 // Health check with rate limit status
 app.get('/health', (req, res) => {
   const rl = getRateLimitStatus();
@@ -59,6 +78,7 @@ app.get('/health', (req, res) => {
   res.json({
     status: 'ok',
     timestamp: new Date().toISOString(),
+    docsUrl: '/api/docs',
     github: {
       authenticated: !!config.githubToken,
       rateLimit: {
@@ -97,7 +117,7 @@ app.listen(PORT, () => {
       '/api/timeline', '/api/issues', '/api/pulse', '/api/agents',
       '/api/repos', '/api/config', '/api/events', '/api/usage', '/api/health',
       '/api/metrics', '/api/metrics/summary', '/api/metrics/agents', '/api/metrics/stats',
-      '/api/sse', '/health',
+      '/api/sse', '/api/docs', '/health',
     ],
   });
 

--- a/server/lib/swagger.js
+++ b/server/lib/swagger.js
@@ -1,0 +1,405 @@
+import swaggerJsdoc from 'swagger-jsdoc'
+import swaggerUi from 'swagger-ui-express'
+
+const options = {
+  definition: {
+    openapi: '3.0.3',
+    info: {
+      title: 'FFS Squad Monitor API',
+      version: '0.1.0',
+      description:
+        'Real-time monitoring API for First Frame Studios AI squad operations. ' +
+        'Provides live heartbeat data, structured logs, GitHub activity, metrics, and SSE streaming.',
+      contact: {
+        name: 'First Frame Studios',
+        url: 'https://github.com/jperezdelreal/ffs-squad-monitor',
+      },
+      license: {
+        name: 'MIT',
+        url: 'https://opensource.org/licenses/MIT',
+      },
+    },
+    servers: [
+      {
+        url: 'http://localhost:3001',
+        description: 'Local development server',
+      },
+    ],
+    tags: [
+      { name: 'Heartbeat', description: 'Ralph scheduler heartbeat monitoring' },
+      { name: 'Logs', description: 'Structured agent logs and streaming' },
+      { name: 'Timeline', description: 'Daily round timeline and statistics' },
+      { name: 'Issues', description: 'GitHub issues across all monitored repos' },
+      { name: 'Pulse', description: 'Daily activity pulse (PRs, issues, agents)' },
+      { name: 'Agents', description: 'Squad agent status and activity' },
+      { name: 'Repos', description: 'Monitored repository information' },
+      { name: 'Config', description: 'Dashboard configuration' },
+      { name: 'Events', description: 'Recent GitHub events across repos' },
+      { name: 'Usage', description: 'GitHub Actions CI/CD usage' },
+      { name: 'Metrics', description: 'Historical metrics and snapshots' },
+      { name: 'SSE', description: 'Server-Sent Events for real-time updates' },
+      { name: 'Health', description: 'Service health and dependency checks' },
+    ],
+    components: {
+      schemas: {
+        Error: {
+          type: 'object',
+          properties: {
+            error: { type: 'string', example: 'Failed to fetch data' },
+          },
+          required: ['error'],
+        },
+        Heartbeat: {
+          type: 'object',
+          properties: {
+            status: { type: 'string', enum: ['idle', 'running', 'error', 'offline', 'unknown'], example: 'running' },
+            round: { type: 'integer', nullable: true, example: 42 },
+            pid: { type: 'integer', nullable: true, example: 12345 },
+            interval: { type: 'integer', nullable: true, description: 'Polling interval in seconds', example: 120 },
+            lastStatus: { type: 'string', nullable: true, example: 'success' },
+            lastDuration: { type: 'number', nullable: true, description: 'Duration of last round in seconds', example: 45.2 },
+            timestamp: { type: 'string', format: 'date-time', nullable: true },
+            consecutiveFailures: { type: 'integer', default: 0 },
+            mode: { type: 'string', nullable: true, example: 'normal' },
+            repos: { type: 'array', items: { type: 'string' } },
+          },
+        },
+        Event: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: '12345678' },
+            type: { type: 'string', example: 'PushEvent' },
+            repo: { type: 'string', example: 'jperezdelreal/flora' },
+            actor: { type: 'string', example: 'oak' },
+            createdAt: { type: 'string', format: 'date-time' },
+            payload: { type: 'object', description: 'Event-specific payload data' },
+          },
+        },
+        Issue: {
+          type: 'object',
+          properties: {
+            repo: { type: 'string', example: 'flora' },
+            repoLabel: { type: 'string', example: 'Flora' },
+            repoEmoji: { type: 'string', example: '🌿' },
+            repoGithub: { type: 'string', example: 'jperezdelreal/flora' },
+            number: { type: 'integer', example: 42 },
+            title: { type: 'string', example: 'Add player movement' },
+            state: { type: 'string', enum: ['open', 'closed'], example: 'open' },
+            url: { type: 'string', format: 'uri' },
+            priority: { type: 'integer', minimum: 0, maximum: 3, description: '0=P0/critical, 3=default' },
+            labels: { type: 'array', items: { type: 'string' }, example: ['squad', 'type:feature'] },
+            assignees: { type: 'array', items: { type: 'string' }, example: ['oak'] },
+            prStatus: { type: 'string', nullable: true, enum: ['open', 'closed', null], description: 'Linked PR state' },
+            createdAt: { type: 'string', format: 'date-time' },
+            updatedAt: { type: 'string', format: 'date-time' },
+          },
+        },
+        Usage: {
+          type: 'object',
+          properties: {
+            source: { type: 'string', enum: ['billing', 'workflow_runs'], description: 'Data source used' },
+            totalMinutesUsed: { type: 'integer', example: 150 },
+            includedMinutes: { type: 'integer', example: 2000 },
+            paidMinutesUsed: { type: 'integer', description: 'Only present when source is billing' },
+            totalRuns: { type: 'integer', description: 'Only present when source is workflow_runs' },
+            percentage: { type: 'integer', minimum: 0, maximum: 100, example: 8 },
+            repos: {
+              type: 'array',
+              description: 'Per-repo breakdown (only when source is workflow_runs)',
+              items: {
+                type: 'object',
+                properties: {
+                  repo: { type: 'string' },
+                  label: { type: 'string' },
+                  emoji: { type: 'string' },
+                  runs: { type: 'integer' },
+                  durationMinutes: { type: 'integer' },
+                },
+              },
+            },
+          },
+        },
+        ConfigRepo: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'flora' },
+            emoji: { type: 'string', example: '🌿' },
+            label: { type: 'string', example: 'Flora' },
+            github: { type: 'string', example: 'jperezdelreal/flora' },
+            owner: { type: 'string', example: 'jperezdelreal' },
+            name: { type: 'string', example: 'flora' },
+            color: { type: 'string', example: '#ef4444' },
+          },
+        },
+        ConfigAgent: {
+          type: 'object',
+          properties: {
+            emoji: { type: 'string', example: '🏗️' },
+            role: { type: 'string', example: 'Lead / Architect' },
+            color: { type: 'string', example: '#58a6ff' },
+            repo: { type: 'string', example: 'FirstFrameStudios' },
+          },
+        },
+        Repo: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'flora' },
+            emoji: { type: 'string', example: '🌿' },
+            label: { type: 'string', example: 'Flora' },
+            github: { type: 'string', example: 'jperezdelreal/flora' },
+            hasSquad: { type: 'boolean', description: 'Whether .squad/ directory exists' },
+            focus: { type: 'string', nullable: true, description: 'Current focus from now.md' },
+            openIssues: { type: 'integer', nullable: true },
+            lastCommit: {
+              type: 'object',
+              nullable: true,
+              properties: {
+                sha: { type: 'string', example: 'abc1234' },
+                message: { type: 'string' },
+              },
+            },
+          },
+        },
+        Timeline: {
+          type: 'object',
+          properties: {
+            date: { type: 'string', format: 'date', example: '2026-03-13' },
+            agents: { type: 'array', items: { type: 'string' }, example: ['ralph', 'solo'] },
+            rounds: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  agent: { type: 'string' },
+                  round: { type: 'integer' },
+                  timestamp: { type: 'string', format: 'date-time' },
+                  duration: { type: 'number', description: 'Duration in seconds' },
+                  outcome: { type: 'string', enum: ['success', 'error'] },
+                  exitCode: { type: 'integer' },
+                  status: { type: 'string' },
+                  phase: { type: 'string' },
+                  consecutiveFailures: { type: 'integer' },
+                  metrics: { type: 'object' },
+                },
+              },
+            },
+            heartbeat: {
+              type: 'object',
+              properties: {
+                status: { type: 'string' },
+                round: { type: 'integer' },
+                lastStatus: { type: 'string' },
+              },
+            },
+            summary: {
+              type: 'object',
+              properties: {
+                total: { type: 'integer' },
+                success: { type: 'integer' },
+                error: { type: 'integer' },
+                avgDuration: { type: 'number' },
+                maxDuration: { type: 'number' },
+              },
+            },
+          },
+        },
+        Pulse: {
+          type: 'object',
+          properties: {
+            prsMergedToday: { type: 'integer', example: 3 },
+            issuesClosedToday: { type: 'integer', example: 5 },
+            activeAgents: { type: 'integer', example: 4 },
+            totalAgents: { type: 'integer', example: 16 },
+          },
+        },
+        Agent: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'solo' },
+            emoji: { type: 'string', example: '🏗️' },
+            role: { type: 'string', example: 'Lead / Architect' },
+            color: { type: 'string', example: '#58a6ff' },
+            repo: { type: 'string', example: 'FirstFrameStudios' },
+            status: { type: 'string', enum: ['idle', 'working', 'blocked'], example: 'working' },
+            lastActivity: { type: 'string', format: 'date-time', nullable: true },
+            currentWork: { type: 'string', nullable: true, description: 'Current task description' },
+          },
+        },
+        LogEntry: {
+          type: 'object',
+          properties: {
+            _agent: { type: 'string', example: 'ralph' },
+            _level: { type: 'string', enum: ['info', 'warn', 'error'] },
+            round: { type: 'integer' },
+            timestamp: { type: 'string', format: 'date-time' },
+            duration: { type: 'number' },
+            exitCode: { type: 'integer' },
+            status: { type: 'string' },
+            phase: { type: 'string' },
+            consecutiveFailures: { type: 'integer' },
+            metrics: { type: 'object' },
+          },
+        },
+        MetricsResponse: {
+          type: 'object',
+          properties: {
+            channel: { type: 'string', enum: ['issues', 'agents', 'actions'] },
+            interval: { type: 'string', enum: ['5m', '15m', '1h', '6h', '1d'] },
+            from: { type: 'string', format: 'date-time', nullable: true },
+            to: { type: 'string', format: 'date-time', nullable: true },
+            count: { type: 'integer' },
+            data: { type: 'array', items: { type: 'object' } },
+          },
+        },
+        AgentMetricsResponse: {
+          type: 'object',
+          properties: {
+            from: { type: 'string', format: 'date-time', nullable: true },
+            to: { type: 'string', format: 'date-time', nullable: true },
+            count: { type: 'integer' },
+            data: { type: 'array', items: { type: 'object' } },
+          },
+        },
+        HealthCheck: {
+          type: 'object',
+          properties: {
+            status: { type: 'string', enum: ['healthy', 'degraded', 'unhealthy'] },
+            timestamp: { type: 'string', format: 'date-time' },
+            dependencies: {
+              type: 'object',
+              properties: {
+                github: {
+                  type: 'object',
+                  properties: {
+                    reachable: { type: 'boolean' },
+                    authenticated: { type: 'boolean' },
+                    rateLimit: {
+                      type: 'object',
+                      properties: {
+                        remaining: { type: 'integer', nullable: true },
+                        limit: { type: 'integer', nullable: true },
+                        resetsAt: { type: 'string', format: 'date-time', nullable: true },
+                        healthy: { type: 'boolean' },
+                      },
+                    },
+                  },
+                },
+                heartbeat: {
+                  type: 'object',
+                  properties: {
+                    fileAccessible: { type: 'boolean' },
+                    status: { type: 'string' },
+                    lastTimestamp: { type: 'string', format: 'date-time', nullable: true },
+                    healthy: { type: 'boolean' },
+                  },
+                },
+                metricsDb: { type: 'object', nullable: true },
+              },
+            },
+            sse: { type: 'object', description: 'SSE connection info' },
+          },
+        },
+        SimpleHealth: {
+          type: 'object',
+          properties: {
+            status: { type: 'string', example: 'ok' },
+            timestamp: { type: 'string', format: 'date-time' },
+            docsUrl: { type: 'string', example: '/api/docs' },
+            github: {
+              type: 'object',
+              properties: {
+                authenticated: { type: 'boolean' },
+                rateLimit: {
+                  type: 'object',
+                  properties: {
+                    remaining: { type: 'integer', nullable: true },
+                    limit: { type: 'integer', nullable: true },
+                    resetsAt: { type: 'string', format: 'date-time', nullable: true },
+                    lastChecked: { type: 'string', format: 'date-time', nullable: true },
+                  },
+                },
+              },
+            },
+            metricsDb: { type: 'object', nullable: true },
+          },
+        },
+      },
+    },
+  },
+  apis: ['./server/api/*.js', './server/index.js'],
+}
+
+export const swaggerSpec = swaggerJsdoc(options)
+
+// Dark theme CSS to match dashboard aesthetic
+const darkThemeCss = `
+  html { box-sizing: border-box; overflow-y: scroll; }
+  body { margin: 0; background: #0d1117 !important; }
+  .swagger-ui {
+    color: #c9d1d9 !important;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif !important;
+  }
+  .swagger-ui .topbar { display: none !important; }
+  .swagger-ui .info .title { color: #58a6ff !important; }
+  .swagger-ui .info p, .swagger-ui .info li { color: #8b949e !important; }
+  .swagger-ui .info a { color: #58a6ff !important; }
+  .swagger-ui .scheme-container { background: #161b22 !important; box-shadow: none !important; }
+  .swagger-ui .opblock-tag { color: #c9d1d9 !important; border-bottom-color: #30363d !important; }
+  .swagger-ui .opblock-tag:hover { background: #161b22 !important; }
+  .swagger-ui .opblock { background: #161b22 !important; border-color: #30363d !important; }
+  .swagger-ui .opblock .opblock-summary { border-color: #30363d !important; }
+  .swagger-ui .opblock .opblock-summary-description { color: #8b949e !important; }
+  .swagger-ui .opblock.opblock-get { border-color: #1f6feb !important; background: rgba(31,111,235,0.05) !important; }
+  .swagger-ui .opblock.opblock-get .opblock-summary { border-color: #1f6feb !important; }
+  .swagger-ui .opblock-body { background: #0d1117 !important; }
+  .swagger-ui table thead tr td, .swagger-ui table thead tr th { color: #c9d1d9 !important; border-bottom-color: #30363d !important; }
+  .swagger-ui .response-col_status { color: #c9d1d9 !important; }
+  .swagger-ui .response-col_description { color: #8b949e !important; }
+  .swagger-ui .responses-inner h4, .swagger-ui .responses-inner h5 { color: #c9d1d9 !important; }
+  .swagger-ui .model-title { color: #c9d1d9 !important; }
+  .swagger-ui .model { color: #c9d1d9 !important; }
+  .swagger-ui .model-toggle::after { background: none !important; }
+  .swagger-ui section.models { border-color: #30363d !important; }
+  .swagger-ui section.models h4 { color: #c9d1d9 !important; border-bottom-color: #30363d !important; }
+  .swagger-ui .model-box { background: #161b22 !important; }
+  .swagger-ui .parameter__name { color: #c9d1d9 !important; }
+  .swagger-ui .parameter__type { color: #8b949e !important; }
+  .swagger-ui input[type=text] { background: #0d1117 !important; color: #c9d1d9 !important; border-color: #30363d !important; }
+  .swagger-ui select { background: #0d1117 !important; color: #c9d1d9 !important; border-color: #30363d !important; }
+  .swagger-ui textarea { background: #0d1117 !important; color: #c9d1d9 !important; border-color: #30363d !important; }
+  .swagger-ui .btn { border-color: #30363d !important; color: #c9d1d9 !important; }
+  .swagger-ui .btn:hover { background: #161b22 !important; }
+  .swagger-ui .btn.execute { background: #238636 !important; border-color: #238636 !important; color: #fff !important; }
+  .swagger-ui .btn.cancel { background: #da3633 !important; border-color: #da3633 !important; }
+  .swagger-ui .highlight-code { background: #161b22 !important; }
+  .swagger-ui .highlight-code .microlight { color: #c9d1d9 !important; background: #161b22 !important; }
+  .swagger-ui .copy-to-clipboard { background: #161b22 !important; }
+  .swagger-ui .loading-container .loading::after { color: #58a6ff !important; }
+  .swagger-ui .response-control-media-type__accept-message { color: #3fb950 !important; }
+  .swagger-ui .markdown p, .swagger-ui .markdown li { color: #8b949e !important; }
+`
+
+export function setupSwagger(app) {
+  app.use(
+    '/api/docs',
+    swaggerUi.serve,
+    swaggerUi.setup(swaggerSpec, {
+      customCss: darkThemeCss,
+      customSiteTitle: 'FFS Squad Monitor — API Docs',
+      customfavIcon: null,
+      swaggerOptions: {
+        docExpansion: 'list',
+        filter: true,
+        showExtensions: true,
+        tryItOutEnabled: true,
+        persistAuthorization: false,
+      },
+    })
+  )
+
+  // Serve raw spec as JSON
+  app.get('/api/docs.json', (req, res) => {
+    res.setHeader('Content-Type', 'application/json')
+    res.json(swaggerSpec)
+  })
+}


### PR DESCRIPTION
Closes #87

## Summary

Adds complete OpenAPI 3.0 documentation for all 19 Express API endpoints, with interactive Swagger UI at \/api/docs\.

## Changes

### New: \server/lib/swagger.js\
- **swagger-jsdoc** configuration with OpenAPI 3.0.3 spec generation
- **16 reusable component schemas**: Heartbeat, Event, Issue, Usage, ConfigRepo, ConfigAgent, Repo, Timeline, Pulse, Agent, LogEntry, MetricsResponse, AgentMetricsResponse, HealthCheck, SimpleHealth, Error
- **Dark theme CSS** matching dashboard aesthetic (GitHub dark palette)
- **Swagger UI** mounted at \/api/docs\ with \Try it out\ enabled by default
- **Raw JSON spec** served at \/api/docs.json\

### Updated: All 13 route handler files
Co-located \@openapi\ JSDoc annotations documenting:

| Endpoint | Tag | Description |
|----------|-----|-------------|
| \GET /api/heartbeat\ | Heartbeat | Ralph scheduler heartbeat status |
| \GET /api/events\ | Events | Aggregated GitHub events (30s cache) |
| \GET /api/issues\ | Issues | Issues across repos with priority sort |
| \GET /api/usage\ | Usage | GitHub Actions CI/CD minutes |
| \GET /api/config\ | Config | Repos + agent roster |
| \GET /api/repos\ | Repos | Repository status + focus |
| \GET /api/timeline\ | Timeline | Daily round timeline + stats |
| \GET /api/pulse\ | Pulse | Daily activity counts |
| \GET /api/agents\ | Agents | Squad agent statuses |
| \GET /api/logs\ | Logs | Structured log entries |
| \GET /api/logs/files\ | Logs | Available log files |
| \GET /api/logs/stream\ | Logs | SSE log streaming |
| \GET /api/metrics\ | Metrics | Historical time-series data |
| \GET /api/metrics/summary\ | Metrics | Daily aggregated summary |
| \GET /api/metrics/agents\ | Metrics | Agent productivity metrics |
| \GET /api/metrics/stats\ | Metrics | DB statistics |
| \GET /api/sse\ | SSE | Real-time event streaming |
| \GET /api/health\ | Health | Detailed dependency health |
| \GET /health\ | Health | Simple health check |

### Updated: \server/index.js\
- Import and mount \setupSwagger(app)\ middleware
- Add \docsUrl: '/api/docs'\ to \/health\ response
- Add \/api/docs\ to startup endpoint log

## Acceptance Criteria
- [x] \swagger-jsdoc\ and \swagger-ui-express\ in dependencies
- [x] All API endpoints documented with OpenAPI annotations
- [x] Swagger UI available at \/api/docs\
- [x] Response schemas defined and accurate
- [x] \Try it out\ works for all GET endpoints
- [x] Dark theme matches dashboard design