### PR TITLE
feat: useSSE hook with Zustand store integration

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,11 +11,15 @@ import { TrendCharts } from './components/TrendCharts';
 import { Analytics } from './components/Analytics';
 import { usePolling } from './hooks/usePolling';
 import { useHealthScore } from './hooks/useHealthScore';
+import { useSSE } from './hooks/useSSE';
 
 function App() {
   const [activeView, setActiveView] = useState('activity');
   const { lastUpdate, isConnected } = usePolling();
   const { score, level, breakdown, staleness, heartbeatAgeMs } = useHealthScore();
+  const { status: sseStatus, reconnect: sseReconnect } = useSSE({
+    channels: ['heartbeat', 'events', 'issues', 'usage'],
+  });
 
   const renderView = () => {
     switch (activeView) {
@@ -50,6 +54,8 @@ function App() {
             healthScore={score}
             healthLevel={level}
             healthBreakdown={breakdown}
+            sseStatus={sseStatus}
+            onSSEReconnect={sseReconnect}
           />
           <StalenessAlert staleness={staleness} heartbeatAgeMs={heartbeatAgeMs} />
           <main className="flex-1 overflow-y-auto p-6 space-y-6">

--- a/src/components/ActivityFeed.jsx
+++ b/src/components/ActivityFeed.jsx
@@ -10,14 +10,16 @@ function getRepoColor(repoName) {
 }
 
 export function ActivityFeed() {
-  const { events, eventsLoading: loading, eventsError: error, fetchEvents } = useStore();
+  const { events, eventsLoading: loading, eventsError: error, fetchEvents, sseStatus } = useStore();
   const [filters, setFilters] = useState({
     repo: 'all',
     type: 'all',
   });
 
   useEffect(() => {
-    fetchEvents();
+    if (sseStatus !== 'streaming') {
+      fetchEvents();
+    }
   }, []);
 
   const getEventIcon = (type) => {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { HealthBadge } from './HealthBadge';
 import { DependencyHealth } from './DependencyHealth';
 
-export function Header({ lastUpdate, isConnected, healthScore, healthLevel, healthBreakdown }) {
+export function Header({ lastUpdate, isConnected, healthScore, healthLevel, healthBreakdown, sseStatus, onSSEReconnect }) {
   const getTimeSince = () => {
     if (!lastUpdate) return 'Never';
     const seconds = Math.floor((Date.now() - lastUpdate) / 1000);
@@ -24,6 +24,17 @@ export function Header({ lastUpdate, isConnected, healthScore, healthLevel, heal
         <div className="flex items-center gap-6">
           <HealthBadge score={healthScore} level={healthLevel} breakdown={healthBreakdown} />
           <DependencyHealth />
+          {/* SSE / Polling mode indicator */}
+          {sseStatus && sseStatus !== 'streaming' && sseStatus !== 'disconnected' && (
+            <button
+              onClick={onSSEReconnect}
+              className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-amber-500/10 border border-amber-500/20 text-xs font-medium text-amber-400 hover:bg-amber-500/20 transition-all"
+              title="Click to reconnect SSE"
+            >
+              <div className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
+              {sseStatus === 'polling' ? 'Polling' : sseStatus === 'reconnecting' ? 'Reconnecting\u2026' : 'Connecting\u2026'}
+            </button>
+          )}
           <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-white/5 border border-white/10">
             <div className="relative">
               <div className={`w-2.5 h-2.5 rounded-full ${isConnected ? 'bg-emerald-500' : 'bg-red-500'}`} />
@@ -32,7 +43,7 @@ export function Header({ lastUpdate, isConnected, healthScore, healthLevel, heal
               )}
             </div>
             <span className={`text-xs font-medium ${isConnected ? 'text-emerald-400' : 'text-red-400'}`}>
-              {isConnected ? 'Live' : 'Offline'}
+              {sseStatus === 'streaming' ? 'Live \u{1F4E1}' : isConnected ? 'Live' : 'Offline'}
             </span>
           </div>
           <div className="flex items-center gap-2 text-sm text-gray-400">

--- a/src/hooks/__tests__/useSSE.test.js
+++ b/src/hooks/__tests__/useSSE.test.js
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useStore, initialState } from '../../store/store'
+
+// Mock EventSource before importing hook
+class MockEventSource {
+  static instances = []
+  constructor(url) {
+    this.url = url
+    this.readyState = 0 // CONNECTING
+    this._listeners = {}
+    MockEventSource.instances.push(this)
+  }
+  addEventListener(type, fn) {
+    if (!this._listeners[type]) this._listeners[type] = []
+    this._listeners[type].push(fn)
+  }
+  removeEventListener(type, fn) {
+    if (!this._listeners[type]) return
+    this._listeners[type] = this._listeners[type].filter(l => l !== fn)
+  }
+  close() {
+    this.readyState = 2
+  }
+  _emit(type, data) {
+    const handlers = this._listeners[type] || []
+    handlers.forEach(fn => fn({
+      type,
+      data: typeof data === 'string' ? data : JSON.stringify(data),
+      lastEventId: data?.id || '',
+    }))
+  }
+  _triggerError() {
+    if (this.onerror) this.onerror(new Event('error'))
+  }
+}
+
+vi.stubGlobal('EventSource', MockEventSource)
+
+const { useSSE } = await import('../../hooks/useSSE')
+
+describe('useSSE', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    MockEventSource.instances = []
+    // Reset only data state, preserve store actions
+    useStore.setState(initialState)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('connects to SSE endpoint with channels query param', () => {
+    const { unmount } = renderHook(() => useSSE({ channels: ['heartbeat', 'events'] }))
+    expect(MockEventSource.instances).toHaveLength(1)
+    expect(MockEventSource.instances[0].url).toBe('/api/sse?channels=heartbeat,events')
+    unmount()
+  })
+
+  it('starts with connecting status', () => {
+    const { result, unmount } = renderHook(() => useSSE())
+    expect(result.current.status).toBe('connecting')
+    unmount()
+  })
+
+  it('transitions to streaming on connected event', () => {
+    const { result, unmount } = renderHook(() => useSSE())
+    const es = MockEventSource.instances[0]
+
+    act(() => {
+      es._emit('connected', { connectionId: 'test-1', channels: ['heartbeat'] })
+    })
+
+    expect(result.current.status).toBe('streaming')
+    expect(result.current.error).toBeNull()
+    unmount()
+  })
+
+  it('updates store heartbeat via SSE event', () => {
+    const { unmount } = renderHook(() => useSSE({ channels: ['heartbeat'] }))
+    const es = MockEventSource.instances[0]
+
+    act(() => {
+      es._emit('connected', {})
+      es._emit('heartbeat:update', {
+        type: 'heartbeat:update',
+        data: { status: 'running', agent: 'ripley' },
+      })
+    })
+
+    const state = useStore.getState()
+    expect(state.heartbeatData).toEqual({ status: 'running', agent: 'ripley' })
+    expect(state.isConnected).toBe(true)
+    unmount()
+  })
+
+  it('prepends new events to store', () => {
+    useStore.setState({ events: [{ id: 'old' }], eventsLoading: false })
+
+    const { unmount } = renderHook(() => useSSE({ channels: ['events'] }))
+    const es = MockEventSource.instances[0]
+
+    act(() => {
+      es._emit('connected', {})
+      es._emit('events:new', {
+        type: 'events:new',
+        data: { id: 'new-1', type: 'PushEvent' },
+      })
+    })
+
+    const state = useStore.getState()
+    expect(state.events[0]).toEqual({ id: 'new-1', type: 'PushEvent' })
+    expect(state.events[1]).toEqual({ id: 'old' })
+    unmount()
+  })
+
+  it('updates issues snapshot in store', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { unmount } = renderHook(() => useSSE({ channels: ['issues'] }))
+    const es = MockEventSource.instances[0]
+
+    act(() => {
+      es._emit('connected', {})
+      es._emit('issues:update', {
+        type: 'issues:update',
+        data: { snapshot: [{ number: 77, title: 'SSE hook' }] },
+      })
+    })
+
+    const state = useStore.getState()
+    expect(state.issues).toEqual([{ number: 77, title: 'SSE hook' }])
+    unmount()
+  })
+
+  it('updates usage in store', () => {
+    const { unmount } = renderHook(() => useSSE({ channels: ['usage'] }))
+    const es = MockEventSource.instances[0]
+
+    act(() => {
+      es._emit('connected', {})
+      es._emit('usage:update', {
+        type: 'usage:update',
+        data: { totalTokens: 50000 },
+      })
+    })
+
+    const state = useStore.getState()
+    expect(state.usage).toEqual({ totalTokens: 50000 })
+    unmount()
+  })
+
+  it('reconnects with exponential backoff on error', () => {
+    const { result, unmount } = renderHook(() => useSSE())
+
+    act(() => {
+      MockEventSource.instances[0]._triggerError()
+    })
+    expect(result.current.status).toBe('reconnecting')
+    expect(MockEventSource.instances).toHaveLength(1)
+
+    act(() => { vi.advanceTimersByTime(1000) })
+    expect(MockEventSource.instances).toHaveLength(2)
+
+    act(() => {
+      MockEventSource.instances[1]._triggerError()
+    })
+    act(() => { vi.advanceTimersByTime(1500) })
+    expect(MockEventSource.instances).toHaveLength(2)
+
+    act(() => { vi.advanceTimersByTime(500) })
+    expect(MockEventSource.instances).toHaveLength(3)
+
+    unmount()
+  })
+
+  it('falls back to polling after 3 consecutive failures', () => {
+    const refreshSpy = vi.fn()
+    useStore.setState({ refreshAll: refreshSpy })
+
+    const { result, unmount } = renderHook(() => useSSE())
+
+    for (let i = 0; i < 3; i++) {
+      act(() => {
+        const es = MockEventSource.instances[MockEventSource.instances.length - 1]
+        es._triggerError()
+      })
+      if (i < 2) {
+        act(() => { vi.advanceTimersByTime(30_000) })
+      }
+    }
+
+    expect(result.current.status).toBe('polling')
+    expect(useStore.getState().sseStatus).toBe('polling')
+    expect(refreshSpy).toHaveBeenCalled()
+
+    unmount()
+  })
+
+  it('retries SSE after 60s even in polling fallback', () => {
+    const refreshSpy = vi.fn()
+    useStore.setState({ refreshAll: refreshSpy })
+
+    const { unmount } = renderHook(() => useSSE())
+
+    for (let i = 0; i < 3; i++) {
+      act(() => {
+        const es = MockEventSource.instances[MockEventSource.instances.length - 1]
+        es._triggerError()
+      })
+      if (i < 2) {
+        act(() => { vi.advanceTimersByTime(30_000) })
+      }
+    }
+
+    const countBefore = MockEventSource.instances.length
+
+    act(() => { vi.advanceTimersByTime(60_000) })
+    expect(MockEventSource.instances.length).toBeGreaterThan(countBefore)
+
+    unmount()
+  })
+
+  it('cleans up on unmount with no memory leaks', () => {
+    const { unmount } = renderHook(() => useSSE())
+    const es = MockEventSource.instances[0]
+
+    unmount()
+
+    expect(es.readyState).toBe(2)
+    expect(useStore.getState().sseStatus).toBe('disconnected')
+  })
+
+  it('reconnect() resets attempts and creates fresh connection', () => {
+    const { result, unmount } = renderHook(() => useSSE())
+
+    act(() => {
+      MockEventSource.instances[0]._triggerError()
+    })
+
+    const countBefore = MockEventSource.instances.length
+
+    act(() => {
+      result.current.reconnect()
+    })
+
+    expect(MockEventSource.instances.length).toBeGreaterThan(countBefore)
+    expect(result.current.status).toBe('connecting')
+
+    unmount()
+  })
+
+  it('uses default channels when none specified', () => {
+    const { unmount } = renderHook(() => useSSE())
+    expect(MockEventSource.instances[0].url).toBe('/api/sse?channels=heartbeat,events,issues,usage')
+    unmount()
+  })
+
+  it('skips malformed event data gracefully', () => {
+    const { unmount } = renderHook(() => useSSE({ channels: ['heartbeat'] }))
+    const es = MockEventSource.instances[0]
+
+    act(() => {
+      es._emit('connected', {})
+    })
+
+    const handlers = es._listeners['heartbeat:update'] || []
+    expect(() => {
+      handlers.forEach(fn => fn({ type: 'heartbeat:update', data: 'not-json{{{', lastEventId: '' }))
+    }).not.toThrow()
+
+    unmount()
+  })
+})

--- a/src/hooks/useSSE.js
+++ b/src/hooks/useSSE.js
@@ -1,0 +1,173 @@
+import { useEffect, useRef, useCallback, useState } from 'react'
+import { useStore } from '../store/store'
+
+const MAX_BACKOFF_MS = 30_000
+const FALLBACK_THRESHOLD = 3
+const FALLBACK_RETRY_MS = 60_000
+const DATA_CHANNELS = ['heartbeat', 'events', 'issues', 'usage']
+
+/**
+ * Custom hook that connects to the SSE endpoint and pushes real-time
+ * updates into the Zustand store.  Falls back to polling after
+ * FALLBACK_THRESHOLD consecutive connection failures.
+ *
+ * @param {Object}  opts
+ * @param {string[]} opts.channels - SSE channels to subscribe to
+ * @returns {{ status: string, error: string|null, reconnect: Function }}
+ */
+export function useSSE({ channels = DATA_CHANNELS } = {}) {
+  const setSseStatus = useStore(s => s.setSseStatus)
+  const handleSSEEvent = useStore(s => s.handleSSEEvent)
+  const refreshAll = useStore(s => s.refreshAll)
+
+  const [status, setStatus] = useState('connecting')
+  const [error, setError] = useState(null)
+
+  const esRef = useRef(null)
+  const attemptsRef = useRef(0)
+  const reconnectTimerRef = useRef(null)
+  const fallbackTimerRef = useRef(null)
+  const fallbackIntervalRef = useRef(null)
+  const lastEventIdRef = useRef(null)
+  const mountedRef = useRef(true)
+
+  const updateStatus = useCallback((s) => {
+    if (!mountedRef.current) return
+    setStatus(s)
+    setSseStatus(s)
+  }, [setSseStatus])
+
+  const cleanup = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current)
+      reconnectTimerRef.current = null
+    }
+    if (fallbackTimerRef.current) {
+      clearTimeout(fallbackTimerRef.current)
+      fallbackTimerRef.current = null
+    }
+    if (fallbackIntervalRef.current) {
+      clearInterval(fallbackIntervalRef.current)
+      fallbackIntervalRef.current = null
+    }
+    if (esRef.current) {
+      esRef.current.close()
+      esRef.current = null
+    }
+  }, [])
+
+  const startPollingFallback = useCallback(() => {
+    updateStatus('polling')
+    refreshAll()
+    fallbackIntervalRef.current = setInterval(refreshAll, 60_000)
+  }, [updateStatus, refreshAll])
+
+  const connect = useCallback(() => {
+    if (esRef.current) {
+      esRef.current.close()
+      esRef.current = null
+    }
+
+    if (!mountedRef.current) return
+
+    const channelParam = channels.join(',')
+    const url = `/api/sse?channels=${channelParam}`
+
+    updateStatus(attemptsRef.current === 0 ? 'connecting' : 'reconnecting')
+    setError(null)
+
+    let es
+    try {
+      es = new EventSource(url)
+    } catch (err) {
+      handleConnectionError(err.message)
+      return
+    }
+
+    esRef.current = es
+
+    es.addEventListener('connected', () => {
+      if (!mountedRef.current) return
+      attemptsRef.current = 0
+      updateStatus('streaming')
+      setError(null)
+
+      if (fallbackIntervalRef.current) {
+        clearInterval(fallbackIntervalRef.current)
+        fallbackIntervalRef.current = null
+      }
+      if (fallbackTimerRef.current) {
+        clearTimeout(fallbackTimerRef.current)
+        fallbackTimerRef.current = null
+      }
+    })
+
+    for (const channel of channels) {
+      es.addEventListener(`${channel}:snapshot`, makeHandler(channel))
+      const suffixes = channel === 'events' ? ['new'] : ['update']
+      for (const suffix of suffixes) {
+        es.addEventListener(`${channel}:${suffix}`, makeHandler(channel))
+      }
+    }
+
+    es.onerror = () => {
+      if (!mountedRef.current) return
+      es.close()
+      esRef.current = null
+      handleConnectionError('SSE connection lost')
+    }
+
+    function makeHandler(channel) {
+      return (event) => {
+        if (!mountedRef.current) return
+        if (event.lastEventId) {
+          lastEventIdRef.current = event.lastEventId
+        }
+        try {
+          const sseEvent = JSON.parse(event.data)
+          handleSSEEvent(channel, sseEvent.type || event.type, sseEvent.data)
+        } catch {
+          // Malformed event data
+        }
+      }
+    }
+
+    function handleConnectionError(msg) {
+      if (!mountedRef.current) return
+      attemptsRef.current++
+      setError(msg)
+
+      if (attemptsRef.current >= FALLBACK_THRESHOLD) {
+        startPollingFallback()
+        fallbackTimerRef.current = setTimeout(() => {
+          attemptsRef.current = 0
+          connect()
+        }, FALLBACK_RETRY_MS)
+        return
+      }
+
+      const delay = Math.min(1000 * Math.pow(2, attemptsRef.current - 1), MAX_BACKOFF_MS)
+      updateStatus('reconnecting')
+      reconnectTimerRef.current = setTimeout(connect, delay)
+    }
+  }, [channels, updateStatus, handleSSEEvent, startPollingFallback])
+
+  const reconnect = useCallback(() => {
+    cleanup()
+    attemptsRef.current = 0
+    connect()
+  }, [cleanup, connect])
+
+  useEffect(() => {
+    mountedRef.current = true
+    connect()
+
+    return () => {
+      mountedRef.current = false
+      cleanup()
+      setSseStatus('disconnected')
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { status, error, reconnect }
+}

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -31,6 +31,9 @@ export const initialState = {
   // Notifications (browser alerts via SSE)
   notifications: [],
   notificationSSEStatus: 'disconnected',
+
+  // SSE connection status
+  sseStatus: 'disconnected',
 }
 
 export const useStore = create((set, get) => ({
@@ -61,6 +64,47 @@ export const useStore = create((set, get) => ({
   clearNotifications: () => set({ notifications: [] }),
 
   setNotificationSSEStatus: (status) => set({ notificationSSEStatus: status }),
+
+  setSseStatus: (status) => set({ sseStatus: status }),
+
+  handleSSEEvent: (channel, eventType, data) => {
+    const handlers = {
+      'heartbeat:update': () => set({
+        heartbeatData: data,
+        isConnected: true,
+        lastUpdate: Date.now(),
+        error: null,
+      }),
+      'events:new': () => set((state) => ({
+        events: [data, ...state.events].slice(0, 500),
+        eventsLoading: false,
+        eventsError: null,
+      })),
+      'events:snapshot': () => set({
+        events: data,
+        eventsLoading: false,
+        eventsError: null,
+      }),
+      'issues:update': () => {
+        set({
+          issues: data.snapshot || data,
+          issuesLoading: false,
+          issuesError: null,
+        })
+        get().fetchAgents()
+      },
+      'usage:update': () => set({
+        usage: data,
+        usageLoading: false,
+        usageError: null,
+      }),
+    }
+
+    const key = `${channel}:${eventType.split(':').pop()}`
+    const fullKey = eventType
+    const handler = handlers[fullKey] || handlers[key]
+    if (handler) handler()
+  },
 
   fetchHeartbeat: async () => {
     try {


### PR DESCRIPTION
Closes #77

## Summary

Custom React hook (`useSSE`) that connects to the SSE endpoint (`/api/sse`) and pushes real-time updates directly into the Zustand store, replacing polling with push-based data delivery.

## What Changed

### New Files
- **`src/hooks/useSSE.js`** — Custom hook managing SSE lifecycle:
  - Subscribes to `heartbeat`, `events`, `issues`, `usage` channels
  - Exponential backoff reconnection (1s → 2s → 4s → max 30s)
  - Falls back to polling after 3 consecutive failures
  - Retries SSE every 60s even in polling fallback mode
  - Clean disconnect on unmount (no memory leaks)
  - Exposes `{ status, error, reconnect }` for components
- **`src/hooks/__tests__/useSSE.test.js`** — 14 unit tests covering connection lifecycle, store updates, backoff, fallback, cleanup

### Modified Files
- **`src/store/store.js`** — Added `sseStatus` state field, `setSseStatus` action, and `handleSSEEvent` dispatcher that maps SSE events to store mutations
- **`src/App.jsx`** — Wires `useSSE` hook alongside existing `usePolling`, passes `sseStatus` to Header
- **`src/components/Header.jsx`** — Shows SSE mode indicator (Streaming / Polling / Reconnecting) with reconnect button
- **`src/components/ActivityFeed.jsx`** — Skips initial `fetchEvents()` when SSE is already streaming

## SSE Event to Store Mapping
| SSE Event | Store Action |
|---|---|
| `heartbeat:update` | `setHeartbeatData(data)` |
| `events:new` | Prepend to events array |
| `events:snapshot` | Replace events array |
| `issues:update` | `set({ issues: data.snapshot })` + re-derive agents |
| `usage:update` | `set({ usage: data })` |

## Testing
- 14 tests pass (vitest)
- Production build passes
- Pre-existing PipelineVisualizer test failure unrelated
