### PR TITLE
feat: data export endpoints (CSV/JSON) for issues, metrics, and usage

### DIFF
--- a/server/api/export.js
+++ b/server/api/export.js
@@ -1,0 +1,234 @@
+import { fetchIssues } from './board.js'
+import { fetchUsageData } from './usage.js'
+import { querySnapshots } from '../lib/metrics-db.js'
+import { toCsv, setDownloadHeaders } from '../lib/csv.js'
+import { handleGitHubError } from '../lib/github-client.js'
+import { logger } from '../lib/logger.js'
+
+const VALID_FORMATS = ['csv', 'json']
+const VALID_STATES = ['open', 'closed', 'all']
+const VALID_CHANNELS = ['issues', 'agents', 'actions']
+
+function getFormat(req) {
+  const url = new URL(req.url, `http://${req.headers.host}`)
+  const qFormat = url.searchParams.get('format')
+  if (qFormat && VALID_FORMATS.includes(qFormat)) return qFormat
+
+  const accept = req.headers.accept || ''
+  if (accept.includes('text/csv')) return 'csv'
+  return 'json'
+}
+
+function dateStamp() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+const ISSUE_COLUMNS = [
+  { key: 'number', label: 'number' },
+  { key: 'title', label: 'title' },
+  { key: 'state', label: 'state' },
+  { key: 'repo', label: 'repo' },
+  { key: 'assignees', label: 'assignee', value: r => (r.assignees || []).join('; ') },
+  { key: 'labels', label: 'labels', value: r => (r.labels || []).join('; ') },
+  { key: 'createdAt', label: 'created_at' },
+  { key: 'closedAt', label: 'closed_at', value: r => r.closedAt || '' },
+  { key: 'url', label: 'url' },
+]
+
+/**
+ * @openapi
+ * /api/export/issues:
+ *   get:
+ *     summary: Export issues as CSV or JSON
+ *     description: Downloads issues across all monitored repos. Supports CSV and JSON via format query param or Accept header.
+ *     tags: [Export]
+ *     parameters:
+ *       - in: query
+ *         name: format
+ *         schema:
+ *           type: string
+ *           enum: [csv, json]
+ *           default: json
+ *         description: Response format
+ *       - in: query
+ *         name: state
+ *         schema:
+ *           type: string
+ *           enum: [open, closed, all]
+ *           default: open
+ *         description: Filter issues by state
+ *       - in: query
+ *         name: repo
+ *         schema:
+ *           type: string
+ *         description: Filter by repo id (e.g. flora)
+ *     responses:
+ *       200:
+ *         description: Issue data as CSV or JSON download
+ *       500:
+ *         description: Export failed
+ */
+export async function exportIssuesRoute(req, res) {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`)
+    const state = url.searchParams.get('state') || 'open'
+    const repoFilter = url.searchParams.get('repo')
+    const format = getFormat(req)
+
+    if (!VALID_STATES.includes(state)) {
+      res.status(400).json({ error: `Invalid state. Must be one of: ${VALID_STATES.join(', ')}` })
+      return
+    }
+
+    let issues = await fetchIssues(state)
+
+    if (repoFilter) {
+      issues = issues.filter(i => i.repo === repoFilter)
+    }
+
+    const filename = `ffs-issues-${dateStamp()}.${format}`
+    setDownloadHeaders(res, filename, format)
+
+    if (format === 'csv') {
+      res.end(toCsv(issues, ISSUE_COLUMNS))
+    } else {
+      res.end(JSON.stringify(issues, null, 2))
+    }
+  } catch (err) {
+    if (handleGitHubError(res, err)) return
+    logger.error('Issue export failed', { error: err.message })
+    res.status(500).json({ error: 'Failed to export issues' })
+  }
+}
+
+/**
+ * @openapi
+ * /api/export/metrics:
+ *   get:
+ *     summary: Export metric snapshots as CSV or JSON
+ *     description: Downloads historical metric snapshots. Supports CSV and JSON via format query param or Accept header.
+ *     tags: [Export]
+ *     parameters:
+ *       - in: query
+ *         name: format
+ *         schema:
+ *           type: string
+ *           enum: [csv, json]
+ *           default: json
+ *         description: Response format
+ *       - in: query
+ *         name: channel
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: [issues, agents, actions]
+ *         description: Metric channel
+ *       - in: query
+ *         name: from
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: Start of date range (ISO 8601)
+ *       - in: query
+ *         name: to
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: End of date range (ISO 8601)
+ *     responses:
+ *       200:
+ *         description: Metric data as CSV or JSON download
+ *       400:
+ *         description: Invalid channel
+ *       500:
+ *         description: Export failed
+ */
+export function exportMetricsRoute(req, res) {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`)
+    const channel = url.searchParams.get('channel')
+    const from = url.searchParams.get('from')
+    const to = url.searchParams.get('to')
+    const format = getFormat(req)
+
+    if (!channel || !VALID_CHANNELS.includes(channel)) {
+      res.status(400).json({ error: `Invalid channel. Must be one of: ${VALID_CHANNELS.join(', ')}` })
+      return
+    }
+
+    const data = querySnapshots(channel, from, to, '5m')
+
+    const filename = `ffs-metrics-${channel}-${dateStamp()}.${format}`
+    setDownloadHeaders(res, filename, format)
+
+    if (format === 'csv') {
+      const METRICS_COLUMNS = [
+        { key: 'timestamp', label: 'timestamp' },
+        { key: 'channel', label: 'channel' },
+        { key: 'data', label: 'data', value: r => JSON.stringify(r.data) },
+      ]
+      res.end(toCsv(data, METRICS_COLUMNS))
+    } else {
+      res.end(JSON.stringify(data, null, 2))
+    }
+  } catch (err) {
+    logger.error('Metrics export failed', { error: err.message })
+    res.status(500).json({ error: 'Failed to export metrics' })
+  }
+}
+
+/**
+ * @openapi
+ * /api/export/usage:
+ *   get:
+ *     summary: Export CI/CD usage as CSV or JSON
+ *     description: Downloads GitHub Actions usage data. Supports CSV and JSON via format query param or Accept header.
+ *     tags: [Export]
+ *     parameters:
+ *       - in: query
+ *         name: format
+ *         schema:
+ *           type: string
+ *           enum: [csv, json]
+ *           default: json
+ *         description: Response format
+ *     responses:
+ *       200:
+ *         description: Usage data as CSV or JSON download
+ *       500:
+ *         description: Export failed
+ */
+export async function exportUsageRoute(req, res) {
+  try {
+    const format = getFormat(req)
+    const usage = await fetchUsageData()
+
+    const filename = `ffs-usage-${dateStamp()}.${format}`
+    setDownloadHeaders(res, filename, format)
+
+    if (format === 'csv') {
+      if (usage.repos && usage.repos.length > 0) {
+        const USAGE_COLUMNS = [
+          { key: 'label', label: 'repo' },
+          { key: 'runs', label: 'workflow_runs' },
+          { key: 'durationMinutes', label: 'duration_minutes' },
+        ]
+        res.end(toCsv(usage.repos, USAGE_COLUMNS))
+      } else {
+        const BILLING_COLUMNS = [
+          { key: 'totalMinutesUsed', label: 'total_minutes_used' },
+          { key: 'includedMinutes', label: 'included_minutes' },
+          { key: 'paidMinutesUsed', label: 'paid_minutes_used' },
+          { key: 'percentage', label: 'usage_percentage' },
+        ]
+        res.end(toCsv([usage], BILLING_COLUMNS))
+      }
+    } else {
+      res.end(JSON.stringify(usage, null, 2))
+    }
+  } catch (err) {
+    if (handleGitHubError(res, err)) return
+    logger.error('Usage export failed', { error: err.message })
+    res.status(500).json({ error: 'Failed to export usage data' })
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,7 @@ import usageRoute from './api/usage.js';
 import healthRoute from './api/health.js';
 import { metricsRoute, metricsSummaryRoute, metricsAgentsRoute, metricsStatsRoute } from './api/metrics.js';
 import sseRoute from './api/sse.js';
+import { exportIssuesRoute, exportMetricsRoute, exportUsageRoute } from './api/export.js';
 
 const app = express();
 
@@ -54,6 +55,9 @@ app.get('/api/metrics/summary', metricsSummaryRoute);
 app.get('/api/metrics/agents', metricsAgentsRoute);
 app.get('/api/metrics/stats', metricsStatsRoute);
 app.get('/api/sse', sseRoute);
+app.get('/api/export/issues', exportIssuesRoute);
+app.get('/api/export/metrics', exportMetricsRoute);
+app.get('/api/export/usage', exportUsageRoute);
 
 /**
  * @openapi
@@ -119,7 +123,8 @@ app.listen(PORT, () => {
       '/api/timeline', '/api/issues', '/api/pulse', '/api/agents',
       '/api/repos', '/api/config', '/api/events', '/api/usage', '/api/health',
       '/api/metrics', '/api/metrics/summary', '/api/metrics/agents', '/api/metrics/stats',
-      '/api/sse', '/api/docs', '/health',
+      '/api/sse', '/api/export/issues', '/api/export/metrics', '/api/export/usage',
+      '/api/docs', '/health',
     ],
   });
 

--- a/server/lib/__tests__/csv.test.js
+++ b/server/lib/__tests__/csv.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { toCsv, setDownloadHeaders } from '../csv.js'
+
+describe('toCsv', () => {
+  it('generates header row and data rows', () => {
+    const rows = [
+      { name: 'Alice', age: 30 },
+      { name: 'Bob', age: 25 },
+    ]
+    const columns = [
+      { key: 'name', label: 'Name' },
+      { key: 'age', label: 'Age' },
+    ]
+    const csv = toCsv(rows, columns)
+    const lines = csv.split('\n')
+    expect(lines[0]).toBe('\uFEFFName,Age')
+    expect(lines[1]).toBe('Alice,30')
+    expect(lines[2]).toBe('Bob,25')
+  })
+
+  it('escapes fields with commas and quotes', () => {
+    const rows = [{ val: 'has, comma' }, { val: 'has "quote"' }]
+    const columns = [{ key: 'val', label: 'Value' }]
+    const csv = toCsv(rows, columns)
+    const lines = csv.split('\n')
+    expect(lines[1]).toBe('"has, comma"')
+    expect(lines[2]).toBe('"has ""quote"""')
+  })
+
+  it('escapes fields with newlines', () => {
+    const rows = [{ val: 'line1\nline2' }]
+    const columns = [{ key: 'val', label: 'Value' }]
+    const csv = toCsv(rows, columns)
+    expect(csv).toContain('"line1\nline2"')
+  })
+
+  it('handles null and undefined values', () => {
+    const rows = [{ a: null, b: undefined }]
+    const columns = [
+      { key: 'a', label: 'A' },
+      { key: 'b', label: 'B' },
+    ]
+    const csv = toCsv(rows, columns)
+    const lines = csv.split('\n')
+    expect(lines[1]).toBe(',')
+  })
+
+  it('supports custom value functions', () => {
+    const rows = [{ tags: ['a', 'b', 'c'] }]
+    const columns = [
+      { key: 'tags', label: 'Tags', value: r => r.tags.join('; ') },
+    ]
+    const csv = toCsv(rows, columns)
+    const lines = csv.split('\n')
+    expect(lines[1]).toBe('a; b; c')
+  })
+
+  it('includes trailing newline', () => {
+    const csv = toCsv([{ x: 1 }], [{ key: 'x', label: 'X' }])
+    expect(csv.endsWith('\n')).toBe(true)
+  })
+})
+
+describe('setDownloadHeaders', () => {
+  it('sets CSV content type and disposition', () => {
+    const headers = {}
+    const res = { setHeader: (k, v) => { headers[k] = v } }
+    setDownloadHeaders(res, 'test.csv', 'csv')
+    expect(headers['Content-Type']).toBe('text/csv; charset=utf-8')
+    expect(headers['Content-Disposition']).toBe('attachment; filename="test.csv"')
+  })
+
+  it('sets JSON content type and disposition', () => {
+    const headers = {}
+    const res = { setHeader: (k, v) => { headers[k] = v } }
+    setDownloadHeaders(res, 'data.json', 'json')
+    expect(headers['Content-Type']).toBe('application/json; charset=utf-8')
+    expect(headers['Content-Disposition']).toBe('attachment; filename="data.json"')
+  })
+})

--- a/server/lib/csv.js
+++ b/server/lib/csv.js
@@ -1,0 +1,33 @@
+﻿// Lightweight CSV serializer with proper escaping
+// UTF-8 BOM for Excel compatibility
+
+const BOM = '\uFEFF'
+
+function escapeField(value) {
+  if (value === null || value === undefined) return ''
+  const str = String(value)
+  if (str.includes('"') || str.includes(',') || str.includes('\n') || str.includes('\r')) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+export function toCsv(rows, columns) {
+  const header = columns.map(c => escapeField(c.label || c.key)).join(',')
+  const lines = rows.map(row =>
+    columns.map(c => {
+      const val = typeof c.value === 'function' ? c.value(row) : row[c.key]
+      return escapeField(val)
+    }).join(',')
+  )
+  return BOM + header + '\n' + lines.join('\n') + '\n'
+}
+
+export function setDownloadHeaders(res, filename, format) {
+  if (format === 'csv') {
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8')
+  } else {
+    res.setHeader('Content-Type', 'application/json; charset=utf-8')
+  }
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`)
+}

--- a/src/components/ActivityFeed.jsx
+++ b/src/components/ActivityFeed.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useStore } from '../store/store';
 import { getConfigSync } from '../services/config';
+import { ExportButton } from './ExportButton';
 
 function getRepoColor(repoName) {
   const config = getConfigSync();
@@ -150,15 +151,18 @@ export function ActivityFeed() {
             </select>
           </div>
 
-          <button
-            onClick={fetchEvents}
-            className="ml-auto px-4 py-2 bg-gradient-to-r from-cyan-500 to-blue-600 text-white rounded-lg text-sm font-medium hover:shadow-lg hover:shadow-cyan-500/25 transition-all flex items-center gap-2"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-            </svg>
-            Refresh
-          </button>
+          <div className="flex items-center gap-2 ml-auto">
+            <ExportButton endpoint="/api/export/issues?state=all" label="Export" />
+            <button
+              onClick={fetchEvents}
+              className="px-4 py-2 bg-gradient-to-r from-cyan-500 to-blue-600 text-white rounded-lg text-sm font-medium hover:shadow-lg hover:shadow-cyan-500/25 transition-all flex items-center gap-2"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+              Refresh
+            </button>
+          </div>
         </div>
       </div>
 

--- a/src/components/Analytics.jsx
+++ b/src/components/Analytics.jsx
@@ -3,6 +3,7 @@ import { TrendLine, BarChart, AreaChart } from './charts'
 import { useMetrics } from '../hooks/useMetrics'
 import { useStore } from '../store/store'
 import { CHART_COLORS } from './charts/chartConfig'
+import { ExportButton } from './ExportButton'
 
 const TIME_RANGES = [
   { id: '7d', label: 'Last 7 days' },
@@ -183,6 +184,7 @@ export function Analytics() {
               </button>
             ))}
           </div>
+          <ExportButton endpoint="/api/export/metrics?channel=issues" label="Export" />
           <button
             onClick={handleRefresh}
             className="px-3 py-1.5 text-xs font-medium bg-white/5 text-gray-400 hover:text-white hover:bg-white/10 rounded-lg border border-white/10 transition-colors"

--- a/src/components/CostTracker.jsx
+++ b/src/components/CostTracker.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useStore } from '../store/store';
+import { ExportButton } from './ExportButton';
 
 export function CostTracker() {
   const { usage, usageLoading: loading, usageError: error, fetchUsage } = useStore();
@@ -50,6 +51,11 @@ export function CostTracker() {
 
   return (
     <div className="space-y-6 animate-fade-in">
+      {/* Export header */}
+      <div className="flex justify-end">
+        <ExportButton endpoint="/api/export/usage" label="Export Usage" />
+      </div>
+
       {/* GitHub Actions Usage */}
       <div className="glass rounded-2xl p-8 border border-emerald-500/30 bg-gradient-to-br from-emerald-500/10 via-transparent to-cyan-500/10 relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-r from-emerald-500/5 to-cyan-500/5 animate-pulse" />

--- a/src/components/ExportButton.jsx
+++ b/src/components/ExportButton.jsx
@@ -1,0 +1,51 @@
+import React, { useState, useRef, useEffect } from 'react'
+
+export function ExportButton({ endpoint, label = 'Export' }) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef(null)
+
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false)
+    }
+    if (open) document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [open])
+
+  function download(format) {
+    const sep = endpoint.includes('?') ? '&' : '?'
+    window.open(`${endpoint}${sep}format=${format}`, '_blank')
+    setOpen(false)
+  }
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="px-3 py-2 bg-white/5 text-gray-400 hover:text-white hover:bg-white/10 rounded-lg text-sm font-medium border border-white/10 transition-colors flex items-center gap-1.5"
+        title={label}
+      >
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+        </svg>
+        {label}
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-1 w-40 rounded-lg bg-gray-800 border border-white/10 shadow-xl z-50 overflow-hidden">
+          <button
+            onClick={() => download('csv')}
+            className="w-full px-4 py-2.5 text-sm text-left text-gray-300 hover:bg-white/10 hover:text-white transition-colors flex items-center gap-2"
+          >
+            Export as CSV
+          </button>
+          <button
+            onClick={() => download('json')}
+            className="w-full px-4 py-2.5 text-sm text-left text-gray-300 hover:bg-white/10 hover:text-white transition-colors flex items-center gap-2"
+          >
+            Export as JSON
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/PipelineVisualizer.jsx
+++ b/src/components/PipelineVisualizer.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useStore } from '../store/store';
+import { ExportButton } from './ExportButton';
 
 const BOTTLENECK_THRESHOLD = 5;
 
@@ -171,15 +172,18 @@ export function PipelineVisualizer() {
             <h2 className="text-2xl font-bold text-white mb-1">Pipeline Status</h2>
             <p className="text-sm text-gray-400">{repoCount} repositories tracked</p>
           </div>
-          <button
-            onClick={fetchIssues}
-            className="px-4 py-2 bg-gradient-to-r from-cyan-500 to-blue-600 text-white rounded-lg text-sm font-medium hover:shadow-lg hover:shadow-cyan-500/25 transition-all flex items-center gap-2"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-            </svg>
-            Refresh
-          </button>
+          <div className="flex items-center gap-2">
+            <ExportButton endpoint="/api/export/issues?state=all" label="Export" />
+            <button
+              onClick={fetchIssues}
+              className="px-4 py-2 bg-gradient-to-r from-cyan-500 to-blue-600 text-white rounded-lg text-sm font-medium hover:shadow-lg hover:shadow-cyan-500/25 transition-all flex items-center gap-2"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+              Refresh
+            </button>
+          </div>
         </div>
         <div className="flex flex-wrap gap-4 text-xs">
           <div className="flex items-center gap-2">

--- a/src/components/TeamBoard.jsx
+++ b/src/components/TeamBoard.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useStore } from '../store/store';
+import { ExportButton } from './ExportButton';
 
 const BLOCK_THRESHOLDS = [
   { maxHours: 4, label: 'Recently blocked', color: 'bg-yellow-500/20 border-yellow-500/40 text-yellow-300', dot: 'bg-yellow-400' },
@@ -113,15 +114,18 @@ export function TeamBoard() {
             <h2 className="text-2xl font-bold text-white mb-1">Team Board</h2>
             <p className="text-sm text-gray-400">{agents.filter(a => a.status === 'active').length} of {agents.length} agents active</p>
           </div>
-          <button
-            onClick={loadTeamData}
-            className="px-4 py-2 bg-gradient-to-r from-cyan-500 to-blue-600 text-white rounded-lg text-sm font-medium hover:shadow-lg hover:shadow-cyan-500/25 transition-all flex items-center gap-2"
-          >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-            </svg>
-            Refresh
-          </button>
+          <div className="flex items-center gap-2">
+            <ExportButton endpoint="/api/export/issues" label="Export" />
+            <button
+              onClick={loadTeamData}
+              className="px-4 py-2 bg-gradient-to-r from-cyan-500 to-blue-600 text-white rounded-lg text-sm font-medium hover:shadow-lg hover:shadow-cyan-500/25 transition-all flex items-center gap-2"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+              </svg>
+              Refresh
+            </button>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
Closes #88

## Summary

Adds three export endpoints that return dashboard data in CSV or JSON format, plus frontend export buttons on all major views.

### Backend

- **\server/lib/csv.js\** — Lightweight CSV serializer with proper field escaping (commas, quotes, newlines) and UTF-8 BOM for Excel compatibility
- **\server/api/export.js\** — Three export routes with OpenAPI annotations:
  - \GET /api/export/issues?format=csv|json&state=open|closed|all&repo=flora\
  - \GET /api/export/metrics?format=csv|json&channel=issues|agents|actions&from=&to=\
  - \GET /api/export/usage?format=csv|json\
- Format negotiation via \?format=\ query param or \Accept: text/csv\ header
- \Content-Disposition: attachment\ header triggers browser download
- Reuses existing \etchIssues()\, \etchUsageData()\, \querySnapshots()\ — no data duplication

### Frontend

- **\ExportButton\** component — download icon with CSV/JSON dropdown, click-outside-to-close
- Added to: ActivityFeed, PipelineVisualizer, TeamBoard, CostTracker, Analytics

### Tests

- 8 unit tests for CSV serializer covering: header generation, field escaping, null handling, custom value functions, download headers

### Files Changed

| File | Change |
|------|--------|
| \server/lib/csv.js\ | New — CSV serializer |
| \server/lib/__tests__/csv.test.js\ | New — 8 tests |
| \server/api/export.js\ | New — 3 export routes |
| \server/index.js\ | Register export routes |
| \src/components/ExportButton.jsx\ | New — dropdown component |
| \src/components/ActivityFeed.jsx\ | Add ExportButton |
| \src/components/Analytics.jsx\ | Add ExportButton |
| \src/components/CostTracker.jsx\ | Add ExportButton |
| \src/components/PipelineVisualizer.jsx\ | Add ExportButton |
| \src/components/TeamBoard.jsx\ | Add ExportButton |