### PR TITLE
feat: alert config panel + notification history panel (#85, #86)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,9 +10,12 @@ import { CostTracker } from './components/CostTracker';
 import { TrendCharts } from './components/TrendCharts';
 import { Analytics } from './components/Analytics';
 import { TimelineSwimlane } from './components/TimelineSwimlane';
+import { Settings } from './components/Settings';
+import { NotificationHistory } from './components/NotificationHistory';
 import { usePolling } from './hooks/usePolling';
 import { useHealthScore } from './hooks/useHealthScore';
 import { useSSE } from './hooks/useSSE';
+import { useNotifications } from './hooks/useNotifications';
 
 function App() {
   const [activeView, setActiveView] = useState('activity');
@@ -21,6 +24,7 @@ function App() {
   const { status: sseStatus, reconnect: sseReconnect } = useSSE({
     channels: ['heartbeat', 'events', 'issues', 'usage'],
   });
+  useNotifications();
 
   const renderView = () => {
     switch (activeView) {
@@ -65,6 +69,8 @@ function App() {
             {renderView()}
           </main>
         </div>
+        <Settings />
+        <NotificationHistory />
       </div>
     </ErrorBoundary>
   );

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { HealthBadge } from './HealthBadge';
 import { DependencyHealth } from './DependencyHealth';
+import { NotificationBell } from './NotificationHistory';
 
 export function Header({ lastUpdate, isConnected, healthScore, healthLevel, healthBreakdown, sseStatus, onSSEReconnect }) {
   const getTimeSince = () => {
@@ -46,6 +47,7 @@ export function Header({ lastUpdate, isConnected, healthScore, healthLevel, heal
               {sseStatus === 'streaming' ? 'Live \u{1F4E1}' : isConnected ? 'Live' : 'Offline'}
             </span>
           </div>
+          <NotificationBell />
           <div className="flex items-center gap-2 text-sm text-gray-400">
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />

--- a/src/components/NotificationHistory.jsx
+++ b/src/components/NotificationHistory.jsx
@@ -1,0 +1,203 @@
+import React, { useEffect, useRef } from 'react'
+import { useStore } from '../store/store'
+
+const SEVERITY_CONFIG = {
+  critical: { icon: '🔴', border: 'border-l-red-500', label: 'Critical' },
+  warning:  { icon: '⚠️', border: 'border-l-amber-500', label: 'Warning' },
+  success:  { icon: '✅', border: 'border-l-emerald-500', label: 'Success' },
+  info:     { icon: 'ℹ️', border: 'border-l-blue-500', label: 'Info' },
+}
+
+function formatRelativeTime(timestamp) {
+  if (!timestamp) return ''
+  const diff = Date.now() - new Date(timestamp).getTime()
+  const seconds = Math.floor(diff / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+function NotificationItem({ notification }) {
+  const cfg = SEVERITY_CONFIG[notification.severity] || SEVERITY_CONFIG.info
+
+  return (
+    <div
+      className={`border-l-4 ${cfg.border} bg-white/5 rounded-r-lg p-3 transition-all hover:bg-white/10 ${
+        !notification.read ? 'ring-1 ring-white/10' : 'opacity-80'
+      }`}
+      style={{ animation: 'slideDown 0.25s ease-out' }}
+    >
+      <div className="flex items-start gap-2.5">
+        <span className="text-base mt-0.5 shrink-0">{cfg.icon}</span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <span className={`text-sm font-medium truncate ${!notification.read ? 'text-white' : 'text-gray-300'}`}>
+              {notification.title}
+            </span>
+            <span className="text-[10px] text-gray-500 shrink-0 font-mono">
+              {formatRelativeTime(notification.timestamp)}
+            </span>
+          </div>
+          {notification.body && (
+            <p className="text-xs text-gray-400 mt-1 line-clamp-2">{notification.body}</p>
+          )}
+          {notification.link && (
+            <a
+              href={notification.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block text-[11px] text-cyan-400 hover:text-cyan-300 mt-1.5 transition-colors"
+            >
+              View details →
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function NotificationBell() {
+  const unreadCount = useStore(s => s.unreadCount)
+  const togglePanel = useStore(s => s.toggleNotificationPanel)
+
+  return (
+    <button
+      onClick={togglePanel}
+      className="relative p-2 rounded-lg text-gray-400 hover:text-white hover:bg-white/10 transition-all"
+      aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
+    >
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+      </svg>
+      {unreadCount > 0 && (
+        <span
+          className="absolute -top-0.5 -right-0.5 flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 text-white text-[10px] font-bold shadow-lg shadow-red-500/30"
+          style={{ animation: 'badgeBounce 0.4s ease-out' }}
+          key={unreadCount}
+        >
+          {unreadCount > 99 ? '99+' : unreadCount}
+        </span>
+      )}
+    </button>
+  )
+}
+
+export function NotificationHistory() {
+  const panelRef = useRef(null)
+  const show = useStore(s => s.showNotificationPanel)
+  const notifications = useStore(s => s.notifications)
+  const markAllRead = useStore(s => s.markAllRead)
+  const clearNotifications = useStore(s => s.clearNotifications)
+  const closeAllPanels = useStore(s => s.closeAllPanels)
+
+  // Close on Escape
+  useEffect(() => {
+    if (!show) return
+    const onKey = (e) => { if (e.key === 'Escape') closeAllPanels() }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [show, closeAllPanels])
+
+  // Close on outside click
+  useEffect(() => {
+    if (!show) return
+    const onClick = (e) => {
+      if (panelRef.current && !panelRef.current.contains(e.target)) {
+        closeAllPanels()
+      }
+    }
+    const timer = setTimeout(() => document.addEventListener('mousedown', onClick), 50)
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener('mousedown', onClick)
+    }
+  }, [show, closeAllPanels])
+
+  if (!show) return null
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40 transition-opacity duration-300" />
+
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        className="fixed right-0 top-0 bottom-0 w-96 z-50 glass border-l border-white/10 flex flex-col"
+        style={{ animation: 'slideInRight 0.25s ease-out' }}
+      >
+        {/* Header */}
+        <div className="p-4 border-b border-white/10 shrink-0">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-2">
+              <span className="text-xl">🔔</span>
+              <h2 className="text-lg font-bold text-white">Notifications</h2>
+              {notifications.length > 0 && (
+                <span className="text-xs text-gray-500 font-mono">({notifications.length})</span>
+              )}
+            </div>
+            <button
+              onClick={closeAllPanels}
+              className="w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:text-white hover:bg-white/10 transition-all"
+              aria-label="Close notifications"
+            >
+              ✕
+            </button>
+          </div>
+          {notifications.length > 0 && (
+            <div className="flex gap-2">
+              <button
+                onClick={markAllRead}
+                className="flex-1 px-3 py-1.5 rounded-lg text-xs font-medium bg-white/5 text-gray-300 border border-white/10 hover:bg-white/10 hover:text-white transition-all"
+              >
+                Mark all as read
+              </button>
+              <button
+                onClick={clearNotifications}
+                className="flex-1 px-3 py-1.5 rounded-lg text-xs font-medium bg-white/5 text-gray-300 border border-white/10 hover:bg-red-500/20 hover:text-red-400 hover:border-red-500/30 transition-all"
+              >
+                Clear all
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Notification list */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-2">
+          {notifications.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-full text-gray-500">
+              <span className="text-4xl mb-3">🔕</span>
+              <p className="text-sm">No notifications yet</p>
+              <p className="text-xs text-gray-600 mt-1">Alerts will appear here when triggered</p>
+            </div>
+          ) : (
+            notifications.map((n) => (
+              <NotificationItem key={n.id} notification={n} />
+            ))
+          )}
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes slideInRight {
+          from { transform: translateX(100%); opacity: 0; }
+          to   { transform: translateX(0);    opacity: 1; }
+        }
+        @keyframes slideDown {
+          from { transform: translateY(-8px); opacity: 0; }
+          to   { transform: translateY(0);    opacity: 1; }
+        }
+        @keyframes badgeBounce {
+          0%   { transform: scale(0.5); }
+          50%  { transform: scale(1.2); }
+          100% { transform: scale(1);   }
+        }
+      `}</style>
+    </>
+  )
+}

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,0 +1,234 @@
+import React, { useEffect, useRef } from 'react'
+import { useStore } from '../store/store'
+
+const ALERT_TYPE_LABELS = {
+  agentBlocked: 'Agent blocked',
+  heartbeatStale: 'Heartbeat stale',
+  buildFailed: 'Build failed',
+  rateLimitWarning: 'Rate limit warning',
+  issueSpike: 'Issue spike',
+  sprintMilestone: 'Sprint milestone',
+}
+
+function Toggle({ checked, onChange, label }) {
+  return (
+    <label className="flex items-center justify-between gap-3 py-2 cursor-pointer group">
+      <span className="text-sm text-gray-300 group-hover:text-white transition-colors">{label}</span>
+      <button
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-cyan-500/50 ${
+          checked ? 'bg-cyan-500' : 'bg-gray-600'
+        }`}
+      >
+        <span
+          className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-lg transform transition-transform duration-200 ${
+            checked ? 'translate-x-4' : 'translate-x-0'
+          }`}
+        />
+      </button>
+    </label>
+  )
+}
+
+function SliderInput({ label, value, onChange, min, max, step = 1, unit = '' }) {
+  return (
+    <div className="py-2">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-sm text-gray-300">{label}</span>
+        <span className="text-xs font-mono text-cyan-400">{value}{unit}</span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full h-1.5 rounded-full appearance-none bg-gray-700 accent-cyan-500 cursor-pointer"
+      />
+      <div className="flex justify-between mt-1">
+        <span className="text-[10px] text-gray-500">{min}{unit}</span>
+        <span className="text-[10px] text-gray-500">{max}{unit}</span>
+      </div>
+    </div>
+  )
+}
+
+function SectionHeader({ children }) {
+  return (
+    <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mt-5 mb-2 first:mt-0">{children}</h3>
+  )
+}
+
+export function Settings() {
+  const panelRef = useRef(null)
+  const show = useStore(s => s.showSettingsPanel)
+  const settings = useStore(s => s.settings)
+  const updateSettings = useStore(s => s.updateSettings)
+  const updateAlertType = useStore(s => s.updateAlertType)
+  const closeAllPanels = useStore(s => s.closeAllPanels)
+
+  // Close on Escape
+  useEffect(() => {
+    if (!show) return
+    const onKey = (e) => { if (e.key === 'Escape') closeAllPanels() }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [show, closeAllPanels])
+
+  // Close on outside click
+  useEffect(() => {
+    if (!show) return
+    const onClick = (e) => {
+      if (panelRef.current && !panelRef.current.contains(e.target)) {
+        closeAllPanels()
+      }
+    }
+    // Delay listener to avoid closing immediately from the button click
+    const timer = setTimeout(() => document.addEventListener('mousedown', onClick), 50)
+    return () => {
+      clearTimeout(timer)
+      document.removeEventListener('mousedown', onClick)
+    }
+  }, [show, closeAllPanels])
+
+  if (!show) return null
+
+  const pollingOptions = [30, 60, 120]
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40 transition-opacity duration-300" />
+
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        className="fixed left-72 top-0 bottom-0 w-96 z-50 glass border-r border-white/10 overflow-y-auto animate-slide-in-left"
+        style={{ animation: 'slideInLeft 0.25s ease-out' }}
+      >
+        <div className="p-6">
+          {/* Header */}
+          <div className="flex items-center justify-between mb-6">
+            <div className="flex items-center gap-2">
+              <span className="text-xl">⚙️</span>
+              <h2 className="text-lg font-bold text-white">Settings</h2>
+            </div>
+            <button
+              onClick={closeAllPanels}
+              className="w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:text-white hover:bg-white/10 transition-all"
+              aria-label="Close settings"
+            >
+              ✕
+            </button>
+          </div>
+
+          {/* Notification Preferences */}
+          <SectionHeader>Notification Preferences</SectionHeader>
+          <div className="space-y-0.5">
+            {Object.entries(ALERT_TYPE_LABELS).map(([key, label]) => (
+              <Toggle
+                key={key}
+                label={label}
+                checked={settings.alertTypes[key]}
+                onChange={(val) => updateAlertType(key, val)}
+              />
+            ))}
+          </div>
+
+          <div className="h-px bg-white/10 my-4" />
+
+          <Toggle
+            label="Enable notification sounds"
+            checked={settings.soundEnabled}
+            onChange={(val) => updateSettings({ soundEnabled: val })}
+          />
+          <Toggle
+            label="Enable desktop notifications"
+            checked={settings.desktopEnabled}
+            onChange={(val) => updateSettings({ desktopEnabled: val })}
+          />
+
+          {/* Threshold Configuration */}
+          <SectionHeader>Threshold Configuration</SectionHeader>
+          <SliderInput
+            label="Heartbeat staleness"
+            value={settings.stalenessThresholdMin}
+            onChange={(val) => updateSettings({ stalenessThresholdMin: val })}
+            min={1}
+            max={30}
+            unit=" min"
+          />
+          <SliderInput
+            label="Rate limit warning"
+            value={settings.rateLimitThreshold}
+            onChange={(val) => updateSettings({ rateLimitThreshold: val })}
+            min={50}
+            max={500}
+            step={10}
+          />
+          <div className="py-2">
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-sm text-gray-300">Issue spike threshold</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                min={1}
+                max={20}
+                value={settings.issueSpikeCount}
+                onChange={(e) => updateSettings({ issueSpikeCount: Math.max(1, Number(e.target.value)) })}
+                className="w-16 px-2 py-1 rounded bg-gray-800 border border-white/10 text-sm text-white text-center focus:outline-none focus:ring-1 focus:ring-cyan-500/50"
+              />
+              <span className="text-xs text-gray-400">issues in</span>
+              <input
+                type="number"
+                min={1}
+                max={60}
+                value={settings.issueSpikeWindowMin}
+                onChange={(e) => updateSettings({ issueSpikeWindowMin: Math.max(1, Number(e.target.value)) })}
+                className="w-16 px-2 py-1 rounded bg-gray-800 border border-white/10 text-sm text-white text-center focus:outline-none focus:ring-1 focus:ring-cyan-500/50"
+              />
+              <span className="text-xs text-gray-400">min</span>
+            </div>
+          </div>
+
+          {/* Display Preferences */}
+          <SectionHeader>Display Preferences</SectionHeader>
+          <div className="py-2">
+            <span className="text-sm text-gray-300 block mb-2">Polling interval</span>
+            <div className="flex gap-2">
+              {pollingOptions.map((opt) => (
+                <button
+                  key={opt}
+                  onClick={() => updateSettings({ pollingInterval: opt })}
+                  className={`flex-1 px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
+                    settings.pollingInterval === opt
+                      ? 'bg-cyan-500/20 text-cyan-400 border border-cyan-500/30'
+                      : 'bg-white/5 text-gray-400 border border-white/10 hover:bg-white/10 hover:text-white'
+                  }`}
+                >
+                  {opt}s
+                </button>
+              ))}
+            </div>
+          </div>
+          <Toggle
+            label="Dashboard auto-refresh"
+            checked={settings.autoRefresh}
+            onChange={(val) => updateSettings({ autoRefresh: val })}
+          />
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes slideInLeft {
+          from { transform: translateX(-100%); opacity: 0; }
+          to   { transform: translateX(0);     opacity: 1; }
+        }
+      `}</style>
+    </>
+  )
+}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useStore } from '../store/store';
 
 const NAV_ITEMS = [
   { id: 'activity', label: 'Activity Feed', icon: '📊', color: 'cyan' },
@@ -11,6 +12,9 @@ const NAV_ITEMS = [
 ];
 
 export function Sidebar({ activeView, onViewChange }) {
+  const toggleSettingsPanel = useStore(s => s.toggleSettingsPanel);
+  const showSettingsPanel = useStore(s => s.showSettingsPanel);
+
   return (
     <aside className="w-72 glass border-r border-white/10 backdrop-blur-xl flex flex-col">
       <div className="p-6 border-b border-white/10">
@@ -54,7 +58,19 @@ export function Sidebar({ activeView, onViewChange }) {
           );
         })}
       </nav>
-      <div className="p-4 border-t border-white/10">
+      <div className="p-4 border-t border-white/10 space-y-3">
+        <button
+          onClick={toggleSettingsPanel}
+          className={`w-full flex items-center gap-3 px-4 py-2.5 rounded-lg transition-all duration-200 group ${
+            showSettingsPanel
+              ? 'bg-gradient-to-r from-cyan-500/20 to-blue-600/20 text-white border border-cyan-500/30'
+              : 'text-gray-400 hover:text-white hover:bg-white/5 border border-transparent'
+          }`}
+          aria-label="Settings"
+        >
+          <span className="text-xl transition-transform group-hover:rotate-45 duration-300">⚙️</span>
+          <span className="text-sm font-medium">Settings</span>
+        </button>
         <div className="text-xs text-gray-500 text-center font-mono">
           v1.0.0 • Made with ❤️
         </div>

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,6 +1,49 @@
 import { create } from 'zustand'
 import { fetchConfig } from '../services/config'
 
+const SETTINGS_KEY = 'ffs-monitor-settings'
+
+const DEFAULT_SETTINGS = {
+  // Per-notification-type toggles
+  alertTypes: {
+    agentBlocked: true,
+    heartbeatStale: true,
+    buildFailed: true,
+    rateLimitWarning: true,
+    issueSpike: false,
+    sprintMilestone: false,
+  },
+  // Sound & desktop
+  soundEnabled: false,
+  desktopEnabled: true,
+  // Thresholds
+  stalenessThresholdMin: 5,
+  rateLimitThreshold: 100,
+  issueSpikeCount: 3,
+  issueSpikeWindowMin: 5,
+  // Display
+  pollingInterval: 60,
+  autoRefresh: true,
+}
+
+function loadSettings() {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY)
+    if (!raw) return { ...DEFAULT_SETTINGS }
+    return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) }
+  } catch {
+    return { ...DEFAULT_SETTINGS }
+  }
+}
+
+function persistSettings(settings) {
+  try {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings))
+  } catch {
+    // localStorage may be unavailable
+  }
+}
+
 export const initialState = {
   // Heartbeat
   heartbeatData: null,
@@ -30,7 +73,15 @@ export const initialState = {
 
   // Notifications (browser alerts via SSE)
   notifications: [],
+  unreadCount: 0,
   notificationSSEStatus: 'disconnected',
+
+  // UI panels
+  showNotificationPanel: false,
+  showSettingsPanel: false,
+
+  // Settings (hydrated from localStorage)
+  settings: loadSettings(),
 
   // SSE connection status
   sseStatus: 'disconnected',
@@ -53,15 +104,61 @@ export const useStore = create((set, get) => ({
 
   setLastUpdate: (timestamp) => set({ lastUpdate: timestamp }),
 
-  addNotification: (notification) => set((state) => ({
-    notifications: [notification, ...state.notifications].slice(0, 100),
+  addNotification: (notification) => set((state) => {
+    const enriched = {
+      ...notification,
+      id: notification.id || `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      timestamp: notification.timestamp || new Date().toISOString(),
+      read: false,
+    }
+    const updated = [enriched, ...state.notifications].slice(0, 50)
+    return {
+      notifications: updated,
+      unreadCount: state.unreadCount + 1,
+    }
+  }),
+
+  removeNotification: (id) => set((state) => {
+    const removed = state.notifications.find(n => n.id === id)
+    return {
+      notifications: state.notifications.filter(n => n.id !== id),
+      unreadCount: removed && !removed.read ? Math.max(0, state.unreadCount - 1) : state.unreadCount,
+    }
+  }),
+
+  markAllRead: () => set((state) => ({
+    notifications: state.notifications.map(n => ({ ...n, read: true })),
+    unreadCount: 0,
   })),
 
-  removeNotification: (id) => set((state) => ({
-    notifications: state.notifications.filter(n => n.id !== id),
+  clearNotifications: () => set({ notifications: [], unreadCount: 0 }),
+
+  toggleNotificationPanel: () => set((state) => ({
+    showNotificationPanel: !state.showNotificationPanel,
+    showSettingsPanel: false,
   })),
 
-  clearNotifications: () => set({ notifications: [] }),
+  toggleSettingsPanel: () => set((state) => ({
+    showSettingsPanel: !state.showSettingsPanel,
+    showNotificationPanel: false,
+  })),
+
+  closeAllPanels: () => set({ showNotificationPanel: false, showSettingsPanel: false }),
+
+  updateSettings: (patch) => set((state) => {
+    const updated = { ...state.settings, ...patch }
+    persistSettings(updated)
+    return { settings: updated }
+  }),
+
+  updateAlertType: (key, value) => set((state) => {
+    const updated = {
+      ...state.settings,
+      alertTypes: { ...state.settings.alertTypes, [key]: value },
+    }
+    persistSettings(updated)
+    return { settings: updated }
+  }),
 
   setNotificationSSEStatus: (status) => set({ notificationSSEStatus: status }),
 


### PR DESCRIPTION
Closes #85, Closes #86

## What

Implements the Alert Configuration Panel and Notification History Panel — Phase 2 of the Notification & Alerts theme.

### Settings Panel (Issue #85)
- Gear icon in sidebar footer opens a slide-over settings panel
- Per-notification-type toggles: agent blocked, heartbeat stale, build failed, rate limit warning, issue spike, sprint milestone
- Threshold configuration: heartbeat staleness slider (1-30min), rate limit slider (50-500), issue spike count/window inputs
- Display preferences: polling interval selector (30s/60s/120s), auto-refresh toggle
- Sound and desktop notification toggles
- All preferences persisted in localStorage under ffs-monitor-settings
- Zustand store hydrates from localStorage on load; changes apply immediately

### Notification History Panel (Issue #86)
- Bell icon in Header with red unread count badge
- Badge bounces briefly when count increases
- Click opens a slide-out drawer from the right
- Chronological list (newest first) with severity color coding (Critical=red, Warning=amber, Success=green, Info=blue)
- Each notification shows severity icon, title, body, relative time, optional link
- Mark all as read and Clear all buttons
- Max 50 notifications (FIFO)
- Closes on Escape key or outside click
- Smooth slide/fade animations

### Store Updates
- settings state with alertTypes, thresholds, display prefs
- notifications[] with id, timestamp, read tracking
- unreadCount, showNotificationPanel, showSettingsPanel
- Actions: updateSettings, updateAlertType, markAllRead, clearNotifications, toggleNotificationPanel, toggleSettingsPanel
- useNotifications hook wired in App.jsx for SSE subscription

## Testing
- Build passes
- All 425 existing tests pass (1 pre-existing PipelineVisualizer failure unrelated)