### PR TITLE
feat: dark/light mode toggle with system preference detection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,9 +55,9 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <div className="flex h-screen bg-[#0a0e14] overflow-hidden">
+      <div className="flex h-screen bg-[#0a0e14] dark:bg-[#0a0e14] light:bg-ops-light-bg overflow-hidden">
         {/* Subtle gradient background */}
-        <div className="fixed inset-0 bg-gradient-to-br from-cyan-500/5 via-transparent to-blue-600/5 pointer-events-none" />
+        <div className="fixed inset-0 bg-gradient-to-br from-cyan-500/5 via-transparent to-blue-600/5 dark:from-cyan-500/5 dark:to-blue-600/5 light:from-cyan-500/10 light:to-blue-600/10 pointer-events-none" />
         
         {/* Mobile overlay */}
         {sidebarOpen && (

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,8 +3,10 @@ import { HealthBadge } from './HealthBadge'
 import { ConnectionStatus } from './ConnectionStatus'
 import { DependencyHealth } from './DependencyHealth'
 import { NotificationBell } from './NotificationHistory'
+import { useTheme } from '../hooks/useTheme'
 
 export function Header({ lastUpdate, isConnected, healthScore, healthLevel, healthBreakdown, sseStatus, onSSEReconnect, onMenuClick }) {
+  const { theme, toggleTheme } = useTheme()
   const getTimeSince = () => {
     if (!lastUpdate) return 'Never'
     const seconds = Math.floor((Date.now() - lastUpdate) / 1000)
@@ -16,7 +18,7 @@ export function Header({ lastUpdate, isConnected, healthScore, healthLevel, heal
   }
 
   return (
-    <header className="glass border-b border-white/10 px-3 sm:px-4 md:px-6 py-3 md:py-4 backdrop-blur-xl">
+    <header className="glass border-b border-white/10 dark:border-white/10 light:border-black/10 px-3 sm:px-4 md:px-6 py-3 md:py-4 backdrop-blur-xl">
       <div className="flex items-center justify-between gap-2 sm:gap-4">
         <div className="flex items-center gap-2 sm:gap-4 min-w-0">
           <button
@@ -28,9 +30,9 @@ export function Header({ lastUpdate, isConnected, healthScore, healthLevel, heal
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
             </svg>
           </button>
-          <h1 className="text-lg sm:text-xl md:text-2xl font-bold text-white tracking-tight truncate">Squad Monitor</h1>
-          <div className="hidden sm:block h-6 w-px bg-white/10" />
-          <span className="hidden sm:inline text-xs sm:text-sm text-gray-400 font-mono truncate">FFS Operations</span>
+          <h1 className="text-lg sm:text-xl md:text-2xl font-bold text-white dark:text-white light:text-gray-900 tracking-tight truncate">Squad Monitor</h1>
+          <div className="hidden sm:block h-6 w-px bg-white/10 dark:bg-white/10 light:bg-black/10" />
+          <span className="hidden sm:inline text-xs sm:text-sm text-gray-400 dark:text-gray-400 light:text-gray-500 font-mono truncate">FFS Operations</span>
         </div>
         <div className="flex items-center gap-2 sm:gap-3 md:gap-6">
           <div className="hidden md:block">
@@ -46,8 +48,24 @@ export function Header({ lastUpdate, isConnected, healthScore, healthLevel, heal
               onReconnect={onSSEReconnect}
             />
           </div>
+          <button
+            onClick={toggleTheme}
+            className="p-2 rounded-lg text-gray-400 dark:text-gray-400 light:text-gray-500 hover:text-white dark:hover:text-white light:hover:text-gray-900 hover:bg-white/10 dark:hover:bg-white/10 light:hover:bg-black/5 transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center"
+            aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+            title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+          >
+            {theme === 'dark' ? (
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+              </svg>
+            ) : (
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+              </svg>
+            )}
+          </button>
           <NotificationBell />
-          <div className="hidden md:flex items-center gap-2 text-sm text-gray-400">
+          <div className="hidden md:flex items-center gap-2 text-sm text-gray-400 dark:text-gray-400 light:text-gray-500">
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -18,22 +18,22 @@ export function Sidebar({ activeView, onViewChange, isOpen, onClose }) {
   return (
     <aside className={`
       fixed lg:static inset-y-0 left-0 z-40
-      w-72 glass border-r border-white/10 backdrop-blur-xl flex flex-col
+      w-72 glass border-r border-white/10 dark:border-white/10 light:border-black/10 backdrop-blur-xl flex flex-col
       transform transition-transform duration-300 ease-in-out
       ${isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
     `}>
-      <div className="p-4 sm:p-6 border-b border-white/10">
+      <div className="p-4 sm:p-6 border-b border-white/10 dark:border-white/10 light:border-black/10">
         <div className="flex items-center gap-3 mb-2">
           <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-cyan-500 to-blue-600 flex items-center justify-center text-xl">
             🎬
           </div>
           <div className="flex-1 min-w-0">
-            <h2 className="text-lg font-bold text-white">FFS Monitor</h2>
-            <p className="text-xs text-gray-400 truncate">First Frame Studios</p>
+            <h2 className="text-lg font-bold text-white dark:text-white light:text-gray-900">FFS Monitor</h2>
+            <p className="text-xs text-gray-400 dark:text-gray-400 light:text-gray-500 truncate">First Frame Studios</p>
           </div>
           <button
             onClick={onClose}
-            className="lg:hidden p-2 text-gray-400 hover:text-white transition-colors"
+            className="lg:hidden p-2 text-gray-400 dark:text-gray-400 light:text-gray-500 hover:text-white dark:hover:text-white light:hover:text-gray-900 transition-colors"
             aria-label="Close menu"
           >
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -51,8 +51,8 @@ export function Sidebar({ activeView, onViewChange, isOpen, onClose }) {
               onClick={() => onViewChange(item.id)}
               className={`w-full flex items-center gap-2 sm:gap-3 px-3 sm:px-4 py-2.5 sm:py-3 rounded-lg transition-all duration-200 group relative min-h-[44px] ${
                 isActive
-                  ? 'bg-gradient-to-r from-cyan-500/20 to-blue-600/20 text-white border border-cyan-500/30 shadow-lg shadow-cyan-500/10'
-                  : 'text-gray-400 hover:text-white hover:bg-white/5 border border-transparent'
+                  ? 'bg-gradient-to-r from-cyan-500/20 to-blue-600/20 text-white dark:text-white light:text-gray-900 border border-cyan-500/30 shadow-lg shadow-cyan-500/10'
+                  : 'text-gray-400 dark:text-gray-400 light:text-gray-500 hover:text-white dark:hover:text-white light:hover:text-gray-900 hover:bg-white/5 dark:hover:bg-white/5 light:hover:bg-black/5 border border-transparent'
               }`}
             >
               {isActive && (
@@ -72,20 +72,20 @@ export function Sidebar({ activeView, onViewChange, isOpen, onClose }) {
           );
         })}
       </nav>
-      <div className="p-3 sm:p-4 border-t border-white/10 space-y-3">
+      <div className="p-3 sm:p-4 border-t border-white/10 dark:border-white/10 light:border-black/10 space-y-3">
         <button
           onClick={toggleSettingsPanel}
           className={`w-full flex items-center gap-2 sm:gap-3 px-3 sm:px-4 py-2.5 rounded-lg transition-all duration-200 group min-h-[44px] ${
             showSettingsPanel
-              ? 'bg-gradient-to-r from-cyan-500/20 to-blue-600/20 text-white border border-cyan-500/30'
-              : 'text-gray-400 hover:text-white hover:bg-white/5 border border-transparent'
+              ? 'bg-gradient-to-r from-cyan-500/20 to-blue-600/20 text-white dark:text-white light:text-gray-900 border border-cyan-500/30'
+              : 'text-gray-400 dark:text-gray-400 light:text-gray-500 hover:text-white dark:hover:text-white light:hover:text-gray-900 hover:bg-white/5 dark:hover:bg-white/5 light:hover:bg-black/5 border border-transparent'
           }`}
           aria-label="Settings"
         >
           <span className="text-lg sm:text-xl transition-transform group-hover:rotate-45 duration-300">⚙️</span>
           <span className="text-sm font-medium">Settings</span>
         </button>
-        <div className="text-xs text-gray-500 text-center font-mono">
+        <div className="text-xs text-gray-500 dark:text-gray-500 light:text-gray-400 text-center font-mono">
           v1.0.0 • Made with ❤️
         </div>
       </div>

--- a/src/hooks/__tests__/useTheme.test.js
+++ b/src/hooks/__tests__/useTheme.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTheme } from '../useTheme'
+
+describe('useTheme', () => {
+  let matchMediaListeners
+  let mockMatchMedia
+
+  beforeEach(() => {
+    matchMediaListeners = []
+    mockMatchMedia = {
+      matches: true,
+      addEventListener: vi.fn((_, handler) => matchMediaListeners.push(handler)),
+      removeEventListener: vi.fn((_, handler) => {
+        matchMediaListeners = matchMediaListeners.filter(h => h !== handler)
+      }),
+    }
+    window.matchMedia = vi.fn(() => mockMatchMedia)
+    localStorage.clear()
+    document.documentElement.classList.remove('dark', 'light')
+  })
+
+  afterEach(() => {
+    document.documentElement.classList.remove('dark', 'light')
+  })
+
+  it('detects system dark preference', () => {
+    mockMatchMedia.matches = true
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('detects system light preference', () => {
+    mockMatchMedia.matches = false
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe('light')
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+  })
+
+  it('reads theme from localStorage', () => {
+    localStorage.setItem('ffs-squad-monitor-theme', 'light')
+    mockMatchMedia.matches = true
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe('light')
+  })
+
+  it('persists theme to localStorage on change', () => {
+    const { result } = renderHook(() => useTheme())
+    act(() => result.current.setTheme('light'))
+    expect(localStorage.getItem('ffs-squad-monitor-theme')).toBe('light')
+  })
+
+  it('toggles between dark and light', () => {
+    mockMatchMedia.matches = true
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe('dark')
+
+    act(() => result.current.toggleTheme())
+    expect(result.current.theme).toBe('light')
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+
+    act(() => result.current.toggleTheme())
+    expect(result.current.theme).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('setTheme sets specific theme', () => {
+    const { result } = renderHook(() => useTheme())
+    act(() => result.current.setTheme('light'))
+    expect(result.current.theme).toBe('light')
+    act(() => result.current.setTheme('dark'))
+    expect(result.current.theme).toBe('dark')
+  })
+
+  it('responds to system preference changes when no stored value', () => {
+    localStorage.clear()
+    mockMatchMedia.matches = true
+    const { result } = renderHook(() => useTheme())
+    expect(result.current.theme).toBe('dark')
+
+    act(() => {
+      matchMediaListeners.forEach(fn => fn({ matches: false }))
+    })
+    expect(result.current.theme).toBe('light')
+  })
+
+  it('ignores invalid values in setTheme', () => {
+    const { result } = renderHook(() => useTheme())
+    const before = result.current.theme
+    act(() => result.current.setTheme('invalid'))
+    expect(result.current.theme).toBe(before)
+  })
+})

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,0 +1,74 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+const STORAGE_KEY = 'ffs-squad-monitor-theme'
+
+function getSystemPreference() {
+  if (typeof window === 'undefined') return 'dark'
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function getInitialTheme() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'dark' || stored === 'light') return stored
+  } catch {
+    // localStorage unavailable
+  }
+  return getSystemPreference()
+}
+
+function applyTheme(theme) {
+  const root = document.documentElement
+  if (theme === 'dark') {
+    root.classList.add('dark')
+    root.classList.remove('light')
+  } else {
+    root.classList.add('light')
+    root.classList.remove('dark')
+  }
+}
+
+export function useTheme() {
+  const [theme, setThemeState] = useState(getInitialTheme)
+  const userExplicitlySet = useRef(false)
+
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
+  useEffect(() => {
+    if (userExplicitlySet.current) {
+      try {
+        localStorage.setItem(STORAGE_KEY, theme)
+      } catch {
+        // localStorage unavailable
+      }
+    }
+  }, [theme])
+
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = (e) => {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (!stored) {
+        setThemeState(e.matches ? 'dark' : 'light')
+      }
+    }
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [])
+
+  const toggleTheme = useCallback(() => {
+    userExplicitlySet.current = true
+    setThemeState((prev) => (prev === 'dark' ? 'light' : 'dark'))
+  }, [])
+
+  const setTheme = useCallback((newTheme) => {
+    if (newTheme === 'dark' || newTheme === 'light') {
+      userExplicitlySet.current = true
+      setThemeState(newTheme)
+    }
+  }, [])
+
+  return { theme, toggleTheme, setTheme }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,12 @@
     -moz-osx-font-smoothing: grayscale;
     background: #0a0e14;
     color: #e4e7eb;
+    transition: background-color 0.3s ease, color 0.3s ease;
+  }
+
+  .light body {
+    background: #f8fafc;
+    color: #1e293b;
   }
 
   #root {
@@ -38,6 +44,22 @@
 
   *::-webkit-scrollbar-thumb:hover {
     background: #4b5563;
+  }
+
+  .light * {
+    scrollbar-color: #cbd5e1 #e2e8f0;
+  }
+
+  .light *::-webkit-scrollbar-track {
+    background: #e2e8f0;
+  }
+
+  .light *::-webkit-scrollbar-thumb {
+    background: #cbd5e1;
+  }
+
+  .light *::-webkit-scrollbar-thumb:hover {
+    background: #94a3b8;
   }
 }
 
@@ -83,5 +105,10 @@
     background: rgba(21, 25, 32, 0.6);
     backdrop-filter: blur(8px);
     border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .light .glass {
+    background: rgba(255, 255, 255, 0.8);
+    border: 1px solid rgba(0, 0, 0, 0.1);
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
@@ -14,6 +15,14 @@ export default {
           hover: '#1e2733',
           text: '#e4e7eb',
           muted: '#9ca3af',
+        },
+        'ops-light': {
+          bg: '#f8fafc',
+          surface: '#ffffff',
+          border: '#e2e8f0',
+          hover: '#f1f5f9',
+          text: '#1e293b',
+          muted: '#64748b',
         },
       },
       fontFamily: {


### PR DESCRIPTION
Closes #115

Implements a theme toggle feature allowing users to switch between dark and light modes with automatic system preference detection.

**Changes:**
- Configured Tailwind with class-based dark mode strategy
- Created useTheme hook with system detection + localStorage persistence
- Added toggle button in Header with sun/moon icons
- Defined light mode color palette (ops-light) in Tailwind config
- Updated Header and Sidebar components with light mode variants
- Added smooth 0.3s transition animations for theme changes
- Updated CSS with light mode scrollbar and glass effects
- Comprehensive test coverage (8 tests for useTheme hook)

**Behavior:**
- Detects system color scheme preference on first visit
- Stores user choice in localStorage for persistence across sessions
- Listens to system theme changes when no stored preference exists
- Manual toggle overrides system preference

**Testing:** All 8 useTheme tests passing