### PR TITLE
feat: LLM token usage tracking and cost monitoring API

### DIFF
--- a/server/api/tokens.js
+++ b/server/api/tokens.js
@@ -1,0 +1,86 @@
+import { logger } from '../lib/logger.js'
+import { queryTokenUsage, getTokenUsageSummary } from '../lib/metrics-db.js'
+import { aggregateByModel, aggregateByAgent } from '../lib/token-usage.js'
+
+/**
+ * @openapi
+ * /api/usage/tokens:
+ *   get:
+ *     summary: Query LLM token usage and costs
+ *     description: Returns token usage records with cost estimates, aggregated by model and agent. Supports filtering by date range and agent.
+ *     tags: [Usage]
+ *     parameters:
+ *       - in: query
+ *         name: from
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: Start of date range (ISO 8601)
+ *       - in: query
+ *         name: to
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *         description: End of date range (ISO 8601)
+ *       - in: query
+ *         name: agent
+ *         schema:
+ *           type: string
+ *         description: Filter by agent name
+ *     responses:
+ *       200:
+ *         description: Token usage data with cost breakdowns
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 summary:
+ *                   type: object
+ *                 byModel:
+ *                   type: object
+ *                 byAgent:
+ *                   type: object
+ *                 records:
+ *                   type: array
+ *       500:
+ *         description: Failed to query token usage
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+export default function tokensRoute(req, res) {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`)
+    const from = url.searchParams.get('from')
+    const to = url.searchParams.get('to')
+    const agent = url.searchParams.get('agent')
+
+    // Validate date params
+    if (from && isNaN(Date.parse(from))) {
+      res.status(400).json({ error: 'Invalid from date format' })
+      return
+    }
+    if (to && isNaN(Date.parse(to))) {
+      res.status(400).json({ error: 'Invalid to date format' })
+      return
+    }
+
+    const records = queryTokenUsage({ from, to, agent })
+    const summary = getTokenUsageSummary({ from, to, agent })
+    const byModel = aggregateByModel(records)
+    const byAgent = aggregateByAgent(records)
+
+    res.json({
+      summary,
+      byModel,
+      byAgent,
+      count: records.length,
+      records,
+    })
+  } catch (err) {
+    logger.error('Token usage query failed', { error: err.message })
+    res.status(500).json({ error: 'Failed to query token usage' })
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -27,6 +27,7 @@ import { metricsRoute, metricsSummaryRoute, metricsAgentsRoute, metricsStatsRout
 import sseRoute from './api/sse.js';
 import { exportIssuesRoute, exportMetricsRoute, exportUsageRoute } from './api/export.js';
 import searchLogsRoute from './api/search.js';
+import tokensRoute from './api/tokens.js';
 
 const app = express();
 
@@ -52,6 +53,7 @@ app.get('/api/repos', reposRoute);
 app.get('/api/config', configRoute);
 app.get('/api/events', eventsRoute);
 app.get('/api/usage', usageRoute);
+app.get('/api/usage/tokens', tokensRoute);
 app.get('/api/health', healthRoute);
 app.get('/api/metrics', metricsRoute);
 app.get('/api/metrics/summary', metricsSummaryRoute);
@@ -124,7 +126,7 @@ app.listen(PORT, () => {
     endpoints: [
       '/api/heartbeat', '/api/logs/files', '/api/logs/stream', '/api/logs',
       '/api/timeline', '/api/issues', '/api/pulse', '/api/agents',
-      '/api/repos', '/api/config', '/api/events', '/api/usage', '/api/health',
+      '/api/repos', '/api/config', '/api/events', '/api/usage', '/api/usage/tokens', '/api/health',
       '/api/metrics', '/api/metrics/summary', '/api/metrics/agents', '/api/metrics/stats',
       '/api/sse', '/api/export/issues', '/api/export/metrics', '/api/export/usage',
       '/api/docs', '/health',

--- a/server/lib/__tests__/metrics-db.test.js
+++ b/server/lib/__tests__/metrics-db.test.js
@@ -83,7 +83,7 @@ describe('Metrics Database', () => {
     it('records schema version', () => {
       const db = metricsDb.getDb()
       const row = db.prepare('SELECT version FROM schema_version').get()
-      expect(row.version).toBe(2)
+      expect(row.version).toBe(3)
     })
 
     it('returns same instance on subsequent getDb() calls', () => {

--- a/server/lib/__tests__/notification-rules.test.js
+++ b/server/lib/__tests__/notification-rules.test.js
@@ -11,6 +11,10 @@ vi.mock('../logger.js', () => ({
   },
 }))
 
+vi.mock('../metrics-db.js', () => ({
+  getTokenUsageSummary: vi.fn(() => ({ requests: 0, totalInputTokens: 0, totalOutputTokens: 0, totalTokens: 0, totalCostUsd: 0 })),
+}))
+
 import {
   checkAgentBlocked,
   checkHeartbeatStale,
@@ -18,9 +22,12 @@ import {
   checkRateLimitWarning,
   checkIssueSpike,
   checkSprintMilestone,
+  checkTokenBudget,
   SEVERITY,
   RULES,
 } from '../notification-rules.js'
+
+import { getTokenUsageSummary } from '../metrics-db.js'
 
 describe('SEVERITY', () => {
   it('exports expected severity levels', () => {
@@ -277,9 +284,42 @@ describe('checkSprintMilestone', () => {
   })
 })
 
+describe('checkTokenBudget', () => {
+  beforeEach(() => {
+    vi.mocked(getTokenUsageSummary).mockReset()
+  })
+
+  it('returns empty when spend is under budget', () => {
+    getTokenUsageSummary.mockReturnValue({ totalCostUsd: 2.50 })
+    expect(checkTokenBudget(5)).toEqual([])
+  })
+
+  it('fires warning when spend exceeds budget', () => {
+    getTokenUsageSummary.mockReturnValue({ totalCostUsd: 7.50 })
+    const result = checkTokenBudget(5)
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('token-budget')
+    expect(result[0].severity).toBe('warning')
+    expect(result[0].body).toContain('$7.50')
+    expect(result[0].body).toContain('$5')
+  })
+
+  it('fires critical when spend exceeds 2x budget', () => {
+    getTokenUsageSummary.mockReturnValue({ totalCostUsd: 12.00 })
+    const result = checkTokenBudget(5)
+    expect(result).toHaveLength(1)
+    expect(result[0].severity).toBe('critical')
+  })
+
+  it('returns empty when db throws', () => {
+    getTokenUsageSummary.mockImplementation(() => { throw new Error('db error') })
+    expect(checkTokenBudget()).toEqual([])
+  })
+})
+
 describe('RULES', () => {
   it('exports all expected rules', () => {
-    expect(RULES).toHaveLength(6)
+    expect(RULES).toHaveLength(7)
     const names = RULES.map(r => r.name)
     expect(names).toContain('agent-blocked')
     expect(names).toContain('heartbeat-stale')
@@ -287,6 +327,7 @@ describe('RULES', () => {
     expect(names).toContain('rate-limit')
     expect(names).toContain('issue-spike')
     expect(names).toContain('sprint-milestone')
+    expect(names).toContain('token-budget')
   })
 
   it('each rule has an evaluate function', () => {

--- a/server/lib/metrics-db.js
+++ b/server/lib/metrics-db.js
@@ -13,7 +13,7 @@ const RETENTION_DAYS = 30
 
 let db = null
 
-const SCHEMA_VERSION = 2
+const SCHEMA_VERSION = 3
 
 const MIGRATIONS = [
   `CREATE TABLE IF NOT EXISTS metrics_snapshots (
@@ -78,6 +78,22 @@ const MIGRATIONS = [
     INSERT INTO log_entries_fts(rowid, message, context, agent, level, timestamp)
     VALUES (new.id, new.message, new.context, new.agent, new.level, new.timestamp);
   END`,
+  // Token usage tracking (schema v3)
+  `CREATE TABLE IF NOT EXISTS token_usage (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    agent TEXT,
+    model TEXT NOT NULL,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    total_tokens INTEGER GENERATED ALWAYS AS (input_tokens + output_tokens) STORED,
+    cost_usd REAL NOT NULL DEFAULT 0,
+    run_id TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_token_usage_timestamp ON token_usage (timestamp DESC)`,
+  `CREATE INDEX IF NOT EXISTS idx_token_usage_agent ON token_usage (agent)`,
+  `CREATE INDEX IF NOT EXISTS idx_token_usage_model ON token_usage (model)`,
 ]
 
 export function getDb() {
@@ -449,6 +465,112 @@ export function searchLogs(options = {}) {
   }))
 
   return { results, total, hasMore, limit, offset }
+}
+
+// --- Token Usage ---
+
+export function insertTokenUsage(entry) {
+  const db = getDb()
+  const stmt = db.prepare(`
+    INSERT INTO token_usage (timestamp, agent, model, input_tokens, output_tokens, cost_usd, run_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `)
+  return stmt.run(
+    entry.timestamp || new Date().toISOString(),
+    entry.agent || null,
+    entry.model,
+    entry.inputTokens || 0,
+    entry.outputTokens || 0,
+    entry.costUsd || 0,
+    entry.runId || null
+  )
+}
+
+export function bulkInsertTokenUsage(entries) {
+  const db = getDb()
+  return db.transaction(() => {
+    const stmt = db.prepare(`
+      INSERT INTO token_usage (timestamp, agent, model, input_tokens, output_tokens, cost_usd, run_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `)
+    for (const entry of entries) {
+      stmt.run(
+        entry.timestamp || new Date().toISOString(),
+        entry.agent || null,
+        entry.model,
+        entry.inputTokens || 0,
+        entry.outputTokens || 0,
+        entry.costUsd || 0,
+        entry.runId || null
+      )
+    }
+  })()
+}
+
+export function queryTokenUsage({ from, to, agent } = {}) {
+  const db = getDb()
+  let query = 'SELECT id, timestamp, agent, model, input_tokens, output_tokens, total_tokens, cost_usd, run_id FROM token_usage WHERE 1=1'
+  const params = []
+
+  if (from) {
+    query += ' AND timestamp >= ?'
+    params.push(from)
+  }
+  if (to) {
+    query += ' AND timestamp <= ?'
+    params.push(to)
+  }
+  if (agent) {
+    query += ' AND agent = ?'
+    params.push(agent)
+  }
+
+  query += ' ORDER BY timestamp DESC'
+  return db.prepare(query).all(...params).map(row => ({
+    id: row.id,
+    timestamp: row.timestamp,
+    agent: row.agent,
+    model: row.model,
+    inputTokens: row.input_tokens,
+    outputTokens: row.output_tokens,
+    totalTokens: row.total_tokens,
+    costUsd: row.cost_usd,
+    runId: row.run_id,
+  }))
+}
+
+export function getTokenUsageSummary({ from, to, agent } = {}) {
+  const db = getDb()
+  let query = `SELECT
+    COUNT(*) as requests,
+    COALESCE(SUM(input_tokens), 0) as totalInput,
+    COALESCE(SUM(output_tokens), 0) as totalOutput,
+    COALESCE(SUM(total_tokens), 0) as totalTokens,
+    COALESCE(SUM(cost_usd), 0) as totalCost
+    FROM token_usage WHERE 1=1`
+  const params = []
+
+  if (from) {
+    query += ' AND timestamp >= ?'
+    params.push(from)
+  }
+  if (to) {
+    query += ' AND timestamp <= ?'
+    params.push(to)
+  }
+  if (agent) {
+    query += ' AND agent = ?'
+    params.push(agent)
+  }
+
+  const row = db.prepare(query).get(...params)
+  return {
+    requests: row.requests,
+    totalInputTokens: row.totalInput,
+    totalOutputTokens: row.totalOutput,
+    totalTokens: row.totalTokens,
+    totalCostUsd: Math.round(row.totalCost * 1_000_000) / 1_000_000,
+  }
 }
 
 // --- Lifecycle ---

--- a/server/lib/notification-rules.js
+++ b/server/lib/notification-rules.js
@@ -1,4 +1,5 @@
 import { logger } from './logger.js'
+import { getTokenUsageSummary } from './metrics-db.js'
 
 const log = logger.child({ component: 'notification-rules' })
 
@@ -221,6 +222,31 @@ export function checkSprintMilestone(currentIssues, previousIssues, milestones =
 }
 
 /**
+ * Rule: Token budget — fires when daily LLM spend exceeds a threshold.
+ * @param {number} dailyBudgetUsd - Daily budget threshold in USD (default $5)
+ * @returns {Array<Object>} notifications
+ */
+export function checkTokenBudget(dailyBudgetUsd = 5) {
+  const today = new Date().toISOString().slice(0, 10)
+  let summary
+  try {
+    summary = getTokenUsageSummary({ from: `${today}T00:00:00.000Z`, to: `${today}T23:59:59.999Z` })
+  } catch {
+    return []
+  }
+
+  if (!summary || summary.totalCostUsd <= dailyBudgetUsd) return []
+
+  const pct = Math.round((summary.totalCostUsd / dailyBudgetUsd) * 100)
+  return [createNotification(
+    'token-budget',
+    summary.totalCostUsd > dailyBudgetUsd * 2 ? SEVERITY.CRITICAL : SEVERITY.WARNING,
+    'LLM token budget exceeded',
+    `Daily LLM spend $${summary.totalCostUsd.toFixed(2)} exceeds $${dailyBudgetUsd} budget (${pct}%)`,
+  )]
+}
+
+/**
  * All notification rules. Each is a pure function:
  * (currentData, previousData) => notification[]
  */
@@ -254,5 +280,9 @@ export const RULES = [
     name: 'sprint-milestone',
     evaluate: (current, previous) =>
       checkSprintMilestone(current.issues, previous.issues),
+  },
+  {
+    name: 'token-budget',
+    evaluate: () => checkTokenBudget(),
   },
 ]

--- a/server/lib/token-usage.js
+++ b/server/lib/token-usage.js
@@ -1,0 +1,143 @@
+import { logger } from './logger.js'
+
+const log = logger.child({ component: 'token-usage' })
+
+// Model pricing per 1M tokens (USD)
+export const MODEL_PRICING = {
+  'gpt-4o':            { input: 2.50,  output: 10.00 },
+  'gpt-4o-mini':       { input: 0.15,  output: 0.60  },
+  'gpt-4-turbo':       { input: 10.00, output: 30.00 },
+  'gpt-4':             { input: 30.00, output: 60.00 },
+  'gpt-3.5-turbo':     { input: 0.50,  output: 1.50  },
+  'claude-sonnet-4-20250514': { input: 3.00,  output: 15.00 },
+  'claude-haiku':      { input: 0.25,  output: 1.25  },
+  'claude-3-5-sonnet': { input: 3.00,  output: 15.00 },
+  'claude-3-opus':     { input: 15.00, output: 75.00 },
+  'copilot':           { input: 0.00,  output: 0.00  },
+}
+
+/**
+ * Calculate cost in USD for a given token count and model.
+ * @param {string} model - Model name (must be a key in MODEL_PRICING)
+ * @param {number} inputTokens - Number of input/prompt tokens
+ * @param {number} outputTokens - Number of output/completion tokens
+ * @returns {{ inputCost: number, outputCost: number, totalCost: number }}
+ */
+export function calculateCost(model, inputTokens, outputTokens) {
+  const pricing = MODEL_PRICING[model]
+  if (!pricing) {
+    log.warn('Unknown model for cost calculation', { model })
+    return { inputCost: 0, outputCost: 0, totalCost: 0 }
+  }
+
+  const inputCost = (inputTokens / 1_000_000) * pricing.input
+  const outputCost = (outputTokens / 1_000_000) * pricing.output
+  return {
+    inputCost: Math.round(inputCost * 1_000_000) / 1_000_000,
+    outputCost: Math.round(outputCost * 1_000_000) / 1_000_000,
+    totalCost: Math.round((inputCost + outputCost) * 1_000_000) / 1_000_000,
+  }
+}
+
+// Regex patterns for extracting token usage from GitHub Actions logs
+const TOKEN_PATTERNS = [
+  // Pattern: "Tokens used: 1234 input, 5678 output (model: gpt-4o)"
+  /Tokens used:\s*(\d+)\s*input,\s*(\d+)\s*output\s*\(model:\s*([^)]+)\)/gi,
+  // Pattern: "prompt_tokens=1234 completion_tokens=5678 model=gpt-4o"
+  /prompt_tokens=(\d+)\s+completion_tokens=(\d+)\s+model=(\S+)/gi,
+  // Pattern: "usage: {"prompt_tokens": 1234, "completion_tokens": 5678}"
+  /"prompt_tokens":\s*(\d+),\s*"completion_tokens":\s*(\d+)/gi,
+]
+
+/**
+ * Parse GitHub Actions log text and extract token usage entries.
+ * @param {string} logText - Raw log output
+ * @param {string} [agent] - Agent name (optional)
+ * @returns {Array<{ agent: string|null, model: string, inputTokens: number, outputTokens: number }>}
+ */
+export function parseTokensFromLog(logText, agent = null) {
+  if (!logText || typeof logText !== 'string') return []
+
+  const entries = []
+
+  for (const pattern of TOKEN_PATTERNS) {
+    pattern.lastIndex = 0
+    let match
+    while ((match = pattern.exec(logText)) !== null) {
+      const inputTokens = parseInt(match[1], 10)
+      const outputTokens = parseInt(match[2], 10)
+      const model = match[3] || 'unknown'
+
+      if (inputTokens >= 0 && outputTokens >= 0) {
+        entries.push({
+          agent,
+          model: model.trim(),
+          inputTokens,
+          outputTokens,
+        })
+      }
+    }
+  }
+
+  return entries
+}
+
+/**
+ * Aggregate token usage records by model.
+ * @param {Array} records - Array of { model, inputTokens, outputTokens } objects
+ * @returns {Object} Aggregated stats keyed by model
+ */
+export function aggregateByModel(records) {
+  const byModel = {}
+
+  for (const record of records) {
+    const key = record.model || 'unknown'
+    if (!byModel[key]) {
+      byModel[key] = { model: key, inputTokens: 0, outputTokens: 0, totalTokens: 0, requests: 0 }
+    }
+    byModel[key].inputTokens += record.inputTokens || 0
+    byModel[key].outputTokens += record.outputTokens || 0
+    byModel[key].totalTokens += (record.inputTokens || 0) + (record.outputTokens || 0)
+    byModel[key].requests += 1
+  }
+
+  // Attach cost to each model bucket
+  for (const entry of Object.values(byModel)) {
+    const cost = calculateCost(entry.model, entry.inputTokens, entry.outputTokens)
+    entry.inputCost = cost.inputCost
+    entry.outputCost = cost.outputCost
+    entry.totalCost = cost.totalCost
+  }
+
+  return byModel
+}
+
+/**
+ * Aggregate token usage records by agent.
+ * @param {Array} records - Array of { agent, model, inputTokens, outputTokens } objects
+ * @returns {Object} Aggregated stats keyed by agent
+ */
+export function aggregateByAgent(records) {
+  const byAgent = {}
+
+  for (const record of records) {
+    const key = record.agent || 'unknown'
+    if (!byAgent[key]) {
+      byAgent[key] = { agent: key, inputTokens: 0, outputTokens: 0, totalTokens: 0, requests: 0, totalCost: 0 }
+    }
+    byAgent[key].inputTokens += record.inputTokens || 0
+    byAgent[key].outputTokens += record.outputTokens || 0
+    byAgent[key].totalTokens += (record.inputTokens || 0) + (record.outputTokens || 0)
+    byAgent[key].requests += 1
+
+    const cost = calculateCost(record.model, record.inputTokens || 0, record.outputTokens || 0)
+    byAgent[key].totalCost += cost.totalCost
+  }
+
+  // Round accumulated costs
+  for (const entry of Object.values(byAgent)) {
+    entry.totalCost = Math.round(entry.totalCost * 1_000_000) / 1_000_000
+  }
+
+  return byAgent
+}


### PR DESCRIPTION
## Summary

Adds LLM token usage tracking and cost monitoring to the backend API.

### New files
- **server/lib/token-usage.js** — Model pricing table, cost calculation, GitHub Actions log parsing, aggregation by model/agent
- **server/api/tokens.js** — \GET /api/usage/tokens\ endpoint with date range + agent filtering

### Modified files
- **server/lib/metrics-db.js** — Schema v3: \	oken_usage\ table with indexes + CRUD functions (\insertTokenUsage\, \ulkInsertTokenUsage\, \queryTokenUsage\, \getTokenUsageSummary\)
- **server/lib/notification-rules.js** — \checkTokenBudget\ rule: warns/criticals when daily LLM spend exceeds budget
- **server/index.js** — Registers \/api/usage/tokens\ route
- **Tests** — Schema version bump to 3, mock \metrics-db\ in notification-rules test, \RULES\ count updated to 7, 4 new \checkTokenBudget\ tests

All 186 server tests pass.

Closes #113